### PR TITLE
Make parameter `old-api` take precedence over Maven settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Example command:
 $ java -jar swagger-brake.jar --new-api=/home/user/petstore_v2.yaml --maven-repo-url=https://oss.jfrog.org/oss-snapshot-local --maven-snapshot-repo-url=https://oss.jfrog.org/oss-snapshot-local --groupId=com.example --artifactId=petstore-api --current-artifact-version=1.0.0-SNAPSHOT --api-filename=something.yaml
 ```
 
+Note: if you provide both `--old-api` and Maven parameters, `--old-api` will take precedence. 
+
 #### Secured Maven repository
 It's also possible that the repository is secured with username and password. The following
 2 parameters can be used to provide the credentials to access the repository:

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/runner/OptionsValidator.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/runner/OptionsValidator.java
@@ -43,13 +43,10 @@ public class OptionsValidator {
         if (isBlank(options.getNewApiPath())) {
             throw new IllegalArgumentException(format("%s must be provided.", getNewApiPathName()));
         }
-        if (isNotBlank(options.getOldApiPath()) && isAnyMavenConfigurationSet(options)) {
-            throw new IllegalArgumentException(format("Maven configuration is detected along with %s. Please use only one of them.", getOldApiPathName()));
-        }
         if (isBlank(options.getOldApiPath()) && !isAnyMavenConfigurationSet(options)) {
             throw new IllegalArgumentException(format("Either %s must be provided or a Maven configuration.", getOldApiPathName()));
         }
-        if (isAnyMavenConfigurationSet(options)) {
+        if (isBlank(options.getOldApiPath()) && isAnyMavenConfigurationSet(options)) {
             if (!isFullMavenConfigurationSet(options)) {
                 Collection<String> missingMavenCliOptions = findMissingMavenConfiguration(options);
                 if (isAnyRepoSet(options)) {

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/runner/download/ArtifactDownloaderHandler.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/runner/download/ArtifactDownloaderHandler.java
@@ -28,7 +28,9 @@ public class ArtifactDownloaderHandler {
      * @param options the {@link Options}.
      */
     public void handle(Options options) {
-        if (isLatestArtifactDownloadEnabled(options)) {
+        if (isOldApiParamSet(options)) {
+            log.debug("Latest artifact resolution will be skipped due to configuration settings");
+        } else if (isLatestArtifactDownloadEnabled(options)) {
             try {
                 log.debug("Latest artifact will be downloaded");
                 String groupId = options.getGroupId();
@@ -46,9 +48,11 @@ public class ArtifactDownloaderHandler {
             }
         } else if (isLatestArtifactDownloadWronglyConfigured(options)) {
             log.warn("Seems like latest artifact resolution is intended to be used but missing some of the parameters");
-        } else {
-            log.debug("Latest artifact resolution will be skipped due to configuration settings");
         }
+    }
+
+    private boolean isOldApiParamSet(Options options) {
+        return isNotBlank(options.getOldApiPath());
     }
 
     private boolean isLatestArtifactDownloadEnabled(Options options) {

--- a/swagger-brake/src/test/java/io/redskap/swagger/brake/runner/OptionsValidatorTest.java
+++ b/swagger-brake/src/test/java/io/redskap/swagger/brake/runner/OptionsValidatorTest.java
@@ -138,21 +138,16 @@ public class OptionsValidatorTest {
     }
 
     @Test
-    public void testValidateThrowsExceptionWhenOldApiPathAndMavenIsConfigured() {
+    public void testValidateDoesNotThrowsExceptionWhenOldApiPathAndMavenIsConfigured() {
         // given
         Options options = new Options();
         options.setOldApiPath("somethingelse");
         options.setNewApiPath("something");
-        options.setMavenRepoUrl("localhost:8080/repo");
-        options.setMavenSnapshotRepoUrl("localhost:8080/snapshot-repo");
         options.setCurrentArtifactVersion("1.0.0-SNAPSHOT");
         options.setGroupId("io.redskap");
         options.setArtifactId("swagger-brake");
         // when
-        Throwable result = Assertions.catchThrowable(() -> underTest.validate(options));
-        // then
-        assertThat(result).isInstanceOf(IllegalArgumentException.class);
-        assertThat(result.getMessage()).contains("oldApiPath");
-        assertThat(result.getMessage()).containsIgnoringCase("maven");
+        underTest.validate(options);
+        // then no exception
     }
 }

--- a/swagger-brake/src/test/java/io/redskap/swagger/brake/runner/download/ArtifactDownloaderHandlerTest.java
+++ b/swagger-brake/src/test/java/io/redskap/swagger/brake/runner/download/ArtifactDownloaderHandlerTest.java
@@ -108,4 +108,21 @@ public class ArtifactDownloaderHandlerTest {
         underTest.handle(options);
         // then nothing happens
     }
+
+    @Test
+    public void testHandleShouldIgnoreMavenSettingsWhenOldApiIsProvided() {
+        // given
+        Options options = new Options();
+        options.setNewApiPath("newApi");
+        options.setOldApiPath("oldApi");
+        options.setMavenRepoUrl("mavenRepoUrl");
+        options.setGroupId("groupId");
+        options.setArtifactId("artifactId");
+        options.setCurrentArtifactVersion("currentVersion");
+
+        // when
+        underTest.handle(options);
+        // then
+        verifyNoMoreInteractions(downloaderFactory, swaggerFileResolver);
+    }
 }


### PR DESCRIPTION
The swagger brake Maven plugin sets default values for the `groupId`, `artifactId`, and `currentVersion` parameters.
This causes an error when using the `oldApi` parameter from the Maven plugin.
Rather than removing the default values from the Maven plugin and introducing breaking changes, this PR updates the logic in the core library.
This should not introduce breaking changes because current users of the library use either the `old-api` param or the Maven settings.