### PR TITLE
Add support for release field in MavenMetadata

### DIFF
--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/maven/maven2/LatestArtifactVersionResolver.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/maven/maven2/LatestArtifactVersionResolver.java
@@ -2,6 +2,7 @@ package io.redskap.swagger.brake.maven.maven2;
 
 import io.redskap.swagger.brake.maven.DownloadOptions;
 import io.redskap.swagger.brake.maven.model.MavenMetadata;
+import io.redskap.swagger.brake.maven.model.MavenVersioning;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,8 @@ class LatestArtifactVersionResolver {
     String resolve(DownloadOptions options) {
         String metadataUrl = urlFactory.createLatestArtifactVersionMetadataUrl(options);
         MavenMetadata mavenMetadata = metadataDownloader.download(requestFactory.create(metadataUrl, options));
-        return mavenMetadata.getVersioning().getLatest();
+        MavenVersioning versioning = mavenMetadata.getVersioning();
+        
+        return versioning.getRelease() != null ? versioning.getRelease() : versioning.getLatest();
     }
 }

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/maven/model/MavenVersioning.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/maven/model/MavenVersioning.java
@@ -11,5 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MavenVersioning {
     private String latest;
+    private String release;
     private MavenSnapshot snapshot;
 }


### PR DESCRIPTION
This change allows swagger-brake to support the following metadata model from Nexus:
```
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>com.test</groupId>
  <artifactId>test-api</artifactId>
  <versioning>
    <release>1.0.567</release>
    <versions>
      <version>1.0.566</version>
      <version>1.0.567</version>
    </versions>
    <lastUpdated>20200901062505</lastUpdated>
  </versioning>
</metadata>

```