### PR TITLE
Prevent removal of deprecated request/response attribute from creating a breaking change

### DIFF
--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/model/Schema.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/model/Schema.java
@@ -160,6 +160,22 @@ public class Schema {
             .collect(Collectors.toCollection(TreeSet::new));
     }
 
+    /**
+     * Returns all the attribute names that are not deprecated recursively.
+     * @return the attribute names.
+     */
+    public Collection<String> getNonDeprecatedAttributeNames() {
+        Collection<SchemaAttribute> schemaAttrs = schemaAttributes;
+        if (CollectionUtils.isEmpty(schemaAttrs)) {
+            schemaAttrs = Optional.ofNullable(schema).map(Schema::getSchemaAttributes).orElse(Collections.emptySet());
+        }
+        return internalGetAttributeData(schemaAttrs, "", identity())
+                .stream()
+                .filter(p -> !p.getRight().isDeprecated())
+                .map(Pair::getLeft)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
     private <T> Collection<Pair<String, T>> internalGetAttributeData(Collection<SchemaAttribute> schemaAttributes, String levelName, Function<SchemaAttribute, T> mappingFunc) {
         List<Pair<String, T>> result = schemaAttributes.stream().map(sA -> Pair.of(generateLeveledName(sA.getName(), levelName), mappingFunc.apply(sA))).collect(toList());
         for (SchemaAttribute schemaAttribute : schemaAttributes) {

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/model/SchemaAttribute.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/model/SchemaAttribute.java
@@ -13,6 +13,7 @@ public class SchemaAttribute implements Comparable<SchemaAttribute> {
     private final String name;
     private final Schema schema;
     private final boolean required;
+    private final boolean deprecated;
 
     public String getName() {
         return name.replace(Schema.LEVEL_DELIMITER_REPLACE_VALUE, Schema.LEVEL_DELIMITER);

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -119,8 +119,10 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
             io.swagger.v3.oas.models.media.Schema newInternalSchema = e.getValue();
             Schema schema = internalTransform(newInternalSchema);
             String attributeName = e.getKey();
+            Boolean deprecatedInSchema = newInternalSchema.getDeprecated();
+            boolean deprecated = deprecatedInSchema == null ? false : deprecatedInSchema;
             boolean required = requiredAttributes.contains(attributeName);
-            result.add(new SchemaAttribute(attributeName, schema, required));
+            result.add(new SchemaAttribute(attributeName, schema, required, deprecated));
         }
         return result;
     }

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/request/RequestTypeAttributeRemovedRule.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/request/RequestTypeAttributeRemovedRule.java
@@ -35,12 +35,19 @@ public class RequestTypeAttributeRemovedRule implements BreakingChangeRule<Reque
                         Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
                         if (newApiSchema.isPresent()) {
                             Schema newSchema = newApiSchema.get();
-                            Collection<String> oldAttributeNames = schema.getAttributeNames();
+                            Set<SchemaAttribute> oldAttributes = schema.getSchemaAttributes();
                             Collection<String> newAttributeNames = newSchema.getAttributeNames();
-                            for (String oldAttributeName : oldAttributeNames) {
+                            for (SchemaAttribute oldAttribute : oldAttributes) {
+                                if (oldAttribute.isDeprecated()) {
+                                    continue;
+                                }
+
+                                String oldAttributeName = oldAttribute.getName();
+
                                 if (!newAttributeNames.contains(oldAttributeName)) {
                                     breakingChanges.add(
-                                        new RequestTypeAttributeRemovedBreakingChange(path.getPath(), path.getMethod(), oldAttributeName));
+                                            new RequestTypeAttributeRemovedBreakingChange(path.getPath(),
+                                                    path.getMethod(), oldAttributeName));
                                 }
                             }
                         }

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/request/RequestTypeAttributeRemovedRule.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/request/RequestTypeAttributeRemovedRule.java
@@ -35,19 +35,12 @@ public class RequestTypeAttributeRemovedRule implements BreakingChangeRule<Reque
                         Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
                         if (newApiSchema.isPresent()) {
                             Schema newSchema = newApiSchema.get();
-                            Set<SchemaAttribute> oldAttributes = schema.getSchemaAttributes();
+                            Collection<String> oldAttributeNames = schema.getNonDeprecatedAttributeNames();
                             Collection<String> newAttributeNames = newSchema.getAttributeNames();
-                            for (SchemaAttribute oldAttribute : oldAttributes) {
-                                if (oldAttribute.isDeprecated()) {
-                                    continue;
-                                }
-
-                                String oldAttributeName = oldAttribute.getName();
-
+                            for (String oldAttributeName : oldAttributeNames) {
                                 if (!newAttributeNames.contains(oldAttributeName)) {
                                     breakingChanges.add(
-                                            new RequestTypeAttributeRemovedBreakingChange(path.getPath(),
-                                                    path.getMethod(), oldAttributeName));
+                                            new RequestTypeAttributeRemovedBreakingChange(path.getPath(), path.getMethod(), oldAttributeName));
                                 }
                             }
                         }

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/response/ResponseTypeAttributeRemovedRule.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/response/ResponseTypeAttributeRemovedRule.java
@@ -36,18 +36,12 @@ public class ResponseTypeAttributeRemovedRule implements BreakingChangeRule<Resp
                             Optional<Schema> newApiSchema = newResponse.getSchemaByMediaType(mediaType);
                             if (newApiSchema.isPresent()) {
                                 Schema newSchema = newApiSchema.get();
-                                Set<SchemaAttribute> oldAttributes = schema.getSchemaAttributes();
+                                Collection<String> oldAttributeNames = schema.getNonDeprecatedAttributeNames();
                                 Collection<String> newAttributeNames = newSchema.getAttributeNames();
-                                for (SchemaAttribute oldAttribute : oldAttributes) {
-                                    if (oldAttribute.isDeprecated()) {
-                                        continue;
-                                    }
-
-                                    String oldAttributeName = oldAttribute.getName();
-
+                                for (String oldAttributeName : oldAttributeNames) {
                                     if (!newAttributeNames.contains(oldAttributeName)) {
                                         breakingChanges.add(
-                                            new ResponseTypeAttributeRemovedBreakingChange(path.getPath(), path.getMethod(), apiResponse.getCode(), oldAttributeName));
+                                                new ResponseTypeAttributeRemovedBreakingChange(path.getPath(), path.getMethod(), apiResponse.getCode(), oldAttributeName));
                                     }
                                 }
                             }

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/response/ResponseTypeAttributeRemovedRule.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/core/rule/response/ResponseTypeAttributeRemovedRule.java
@@ -36,9 +36,15 @@ public class ResponseTypeAttributeRemovedRule implements BreakingChangeRule<Resp
                             Optional<Schema> newApiSchema = newResponse.getSchemaByMediaType(mediaType);
                             if (newApiSchema.isPresent()) {
                                 Schema newSchema = newApiSchema.get();
-                                Collection<String> oldAttributeNames = schema.getAttributeNames();
+                                Set<SchemaAttribute> oldAttributes = schema.getSchemaAttributes();
                                 Collection<String> newAttributeNames = newSchema.getAttributeNames();
-                                for (String oldAttributeName : oldAttributeNames) {
+                                for (SchemaAttribute oldAttribute : oldAttributes) {
+                                    if (oldAttribute.isDeprecated()) {
+                                        continue;
+                                    }
+
+                                    String oldAttributeName = oldAttribute.getName();
+
                                     if (!newAttributeNames.contains(oldAttributeName)) {
                                         breakingChanges.add(
                                             new ResponseTypeAttributeRemovedBreakingChange(path.getPath(), path.getMethod(), apiResponse.getCode(), oldAttributeName));

--- a/swagger-brake/src/main/java/io/redskap/swagger/brake/report/StdOutReporter.java
+++ b/swagger-brake/src/main/java/io/redskap/swagger/brake/report/StdOutReporter.java
@@ -35,7 +35,9 @@ class StdOutReporter implements Reporter, CheckableReporter {
     }
 
     private void printIfNotNull(String str) {
-        System.out.println(str);
+        if (str != null) {
+            System.out.println(str);
+        }
     }
 
     @Override

--- a/swagger-brake/src/test/java/io/redskap/swagger/brake/core/model/transformer/SchemaTransformerTest.java
+++ b/swagger-brake/src/test/java/io/redskap/swagger/brake/core/model/transformer/SchemaTransformerTest.java
@@ -50,10 +50,10 @@ public class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("bark", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("bark", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));
@@ -86,9 +86,9 @@ public class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));
@@ -129,10 +129,10 @@ public class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef, catRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));
@@ -173,10 +173,10 @@ public class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef, catRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false),
-            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false),
+            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));

--- a/swagger-brake/src/test/java/io/redskap/swagger/brake/integration/v2/request/RequestTypeAttributeRemovedIntTest.java
+++ b/swagger-brake/src/test/java/io/redskap/swagger/brake/integration/v2/request/RequestTypeAttributeRemovedIntTest.java
@@ -88,4 +88,29 @@ public class RequestTypeAttributeRemovedIntTest extends AbstractSwaggerBrakeIntT
         assertThat(result).hasSize(3);
         assertThat(result).hasSameElementsAs(expected);
     }
+
+    @Test
+    public void testRequestTypeChangeIsNotBreakingChangeWhenDeprecatedExistingAttributeRemoved() {
+        // given
+        String oldApiPath = "swaggers/v3/request/attributeremoved-deprecated/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/attributeremoved-deprecated/petstore_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void testRequestTypeChangeIsBreakingChangeWhenExistingAttributeRemoved_V3Schema() {
+        // given
+        String oldApiPath = "swaggers/v3/request/attributeremoved/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/attributeremoved/petstore_v2.yaml";
+        RequestTypeAttributeRemovedBreakingChange bc1 = new RequestTypeAttributeRemovedBreakingChange("/pet", HttpMethod.PATCH, "id");
+        Collection<BreakingChange> expected = Arrays.asList(bc1);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).hasSameElementsAs(expected);
+    }
 }

--- a/swagger-brake/src/test/java/io/redskap/swagger/brake/integration/v2/response/ResponseTypeAttributeRemovedIntTest.java
+++ b/swagger-brake/src/test/java/io/redskap/swagger/brake/integration/v2/response/ResponseTypeAttributeRemovedIntTest.java
@@ -88,4 +88,30 @@ public class ResponseTypeAttributeRemovedIntTest extends AbstractSwaggerBrakeInt
         assertThat(result).hasSize(3);
         assertThat(result).hasSameElementsAs(expected);
     }
+
+    @Test
+    public void testResponseTypeChangeIsNotBreakingChangeWhenDeprecatedExistingAttributeRemoved() {
+        // given
+        String oldApiPath = "swaggers/v3/response/attributeremoved-deprecated/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/attributeremoved-deprecated/petstore_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void testResponseTypeChangeIsBreakingChangeWhenExistingAttributeRemoved_V3Schema() {
+        // given
+        String oldApiPath = "swaggers/v3/response/attributeremoved/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/attributeremoved/petstore_v2.yaml";
+        ResponseTypeAttributeRemovedBreakingChange bc1 = new ResponseTypeAttributeRemovedBreakingChange("/pet", HttpMethod.PATCH, "201", "id");
+        ResponseTypeAttributeRemovedBreakingChange bc2 = new ResponseTypeAttributeRemovedBreakingChange("/pet", HttpMethod.PATCH, "201", "breed");
+        Collection<BreakingChange> expected = Arrays.asList(bc1, bc2);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).hasSameElementsAs(expected);
+    }
 }

--- a/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved-deprecated/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved-deprecated/petstore.yaml
@@ -1,0 +1,41 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+                - $ref: '#/components/schemas/Dog'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        id:
+          type: integer
+          deprecated: true
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved-deprecated/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved-deprecated/petstore_v2.yaml
@@ -1,0 +1,38 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+                - $ref: '#/components/schemas/Dog'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved/petstore.yaml
@@ -1,0 +1,40 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+                - $ref: '#/components/schemas/Dog'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        id:
+          type: integer
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/attributeremoved/petstore_v2.yaml
@@ -1,0 +1,38 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+                - $ref: '#/components/schemas/Dog'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved-deprecated/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved-deprecated/petstore.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+          content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        id:
+          type: integer
+          deprecated: true
+        breed:
+          type: string
+          deprecated: true
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved-deprecated/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved-deprecated/petstore_v2.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved/petstore.yaml
@@ -1,0 +1,42 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+          content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        id:
+          type: integer
+        breed:
+          type: string
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/attributeremoved/petstore_v2.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    patch:
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Pet'
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
I tried to implement it according to the discussion in #97
Please have a critical look at it as this (Java) is foreign territory to me. 🔥