### PR TITLE
Align renovate config with docktape org standards

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,35 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "group:allNonMajor"
+    "config:recommended"
   ],
+  "minimumReleaseAge": "30 days",
+  "schedule": ["on monday"],
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "enabled": true,
+    "schedule": ["at any time"]
+  },
   "ignorePaths": [
     "docs/**",
     "swagger-brake-integration-tests/src/test/resources/example-projects/**"
   ],
   "packageRules": [
+    {
+      "description": "Group all Gradle and Gradle wrapper updates",
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": "jvm-dependencies"
+    },
+    {
+      "description": "Group all Docker base image updates",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "groupName": "docker-base-images"
+    },
+    {
+      "description": "Group all GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
     {
       "matchPackageNames": [
         "io.swagger.parser.v3:swagger-parser"


### PR DESCRIPTION
## Summary

- Add `schedule: ["on monday"]` and `minimumReleaseAge: "30 days"` to match the docktape private org config
- Add `vulnerabilityAlerts` block so security fixes bypass the schedule and age gate
- Replace `group:allNonMajor` with explicit manager-based grouping (`jvm-dependencies`, `docker-base-images`, `github-actions`)
- Drop `group:allNonMajor` from `extends` - the explicit groups cover everything relevant

## Notes

Mirrors the docktape private org renovate config. Subfolder-based npm grouping was intentionally skipped (not applicable here).