### PR TITLE
feat(R021): detect when a field gains an enum constraint

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameEnumBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameEnumBreakingChange.java
@@ -1,0 +1,30 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestBodyBecameEnumBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String propertyName;
+
+    @Override
+    public String getMessage() {
+        return format("%s at %s %s has been constrained to an enum where it had no restriction", propertyName, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R021";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameEnumRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameEnumRule.java
@@ -1,0 +1,99 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Request;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.model.parameter.RequestParameter;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestBodyBecameEnumRule implements BreakingChangeRule<RequestBodyBecameEnumBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestBodyBecameEnumBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestBodyBecameEnumBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                checkRequestBody(path, newPath, breakingChanges);
+                checkRequestParameters(path, newPath, breakingChanges);
+            }
+        }
+        return breakingChanges;
+    }
+
+    private void checkRequestBody(Path path, Path newPath, Set<RequestBodyBecameEnumBreakingChange> breakingChanges) {
+        Optional<Request> requestBody = path.getRequestBody();
+        Optional<Request> newRequestBody = newPath.getRequestBody();
+        if (!requestBody.isPresent() || !newRequestBody.isPresent()) {
+            return;
+        }
+        for (Map.Entry<MediaType, Schema> entry : requestBody.get().getMediaTypes().entrySet()) {
+            MediaType mediaType = entry.getKey();
+            Schema oldSchema = entry.getValue();
+            Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
+            if (!newApiSchema.isPresent()) {
+                continue;
+            }
+            Schema newSchema = newApiSchema.get();
+            Map<String, Schema> oldSchemas = oldSchema.getSchemasRecursively();
+            Map<String, Schema> newSchemas = newSchema.getSchemasRecursively();
+            for (Map.Entry<String, Schema> schemaEntry : oldSchemas.entrySet()) {
+                String propertyName = schemaEntry.getKey();
+                Schema oldPropertySchema = schemaEntry.getValue();
+                Schema newPropertySchema = newSchemas.get(propertyName);
+                if (newPropertySchema == null) {
+                    continue;
+                }
+                if (CollectionUtils.isEmpty(oldPropertySchema.getEnumValues())
+                        && CollectionUtils.isNotEmpty(newPropertySchema.getEnumValues())) {
+                    breakingChanges.add(
+                        new RequestBodyBecameEnumBreakingChange(path.getPath(), path.getMethod(), propertyName));
+                }
+            }
+        }
+    }
+
+    private void checkRequestParameters(Path path, Path newPath, Set<RequestBodyBecameEnumBreakingChange> breakingChanges) {
+        if (CollectionUtils.isEmpty(path.getRequestParameters())) {
+            return;
+        }
+        for (RequestParameter requestParameter : path.getRequestParameters()) {
+            Optional<RequestParameter> newRequestParameter = newPath.getRequestParameterByName(requestParameter.getName());
+            if (!newRequestParameter.isPresent()) {
+                continue;
+            }
+            Optional<Schema> oldSchema = requestParameter.getSchema();
+            Optional<Schema> newSchema = newRequestParameter.get().getSchema();
+            if (!oldSchema.isPresent() || !newSchema.isPresent()) {
+                continue;
+            }
+            if (CollectionUtils.isEmpty(oldSchema.get().getEnumValues())
+                    && CollectionUtils.isNotEmpty(newSchema.get().getEnumValues())) {
+                breakingChanges.add(
+                    new RequestBodyBecameEnumBreakingChange(path.getPath(), path.getMethod(), requestParameter.getName()));
+            }
+        }
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/request/RequestBodyBecameEnumIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/request/RequestBodyBecameEnumIntTest.java
@@ -1,0 +1,36 @@
+package com.docktape.swagger.brake.integration.v2.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestBodyBecameEnumBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RequestBodyBecameEnumIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testBodyPropertyGainingEnumIsDetected() {
+        // given
+        String oldApiPath = "swaggers/v2/request/becameenum/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/becameenum/petstore_v2.yaml";
+        RequestBodyBecameEnumBreakingChange bc =
+            new RequestBodyBecameEnumBreakingChange("/store/order", HttpMethod.POST, "status");
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/request/becameenum/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/becameenum/petstore.yaml
@@ -1,0 +1,41 @@
+---
+swagger: "2.0"
+info:
+  description: "Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /store/order:
+    post:
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      status:
+        type: "string"
+        description: "Order Status"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/becameenum/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/becameenum/petstore_v2.yaml
@@ -1,0 +1,45 @@
+---
+swagger: "2.0"
+info:
+  description: "Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /store/order:
+    post:
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      status:
+        type: "string"
+        description: "Order Status"
+        enum:
+        - "placed"
+        - "approved"
+        - "delivered"


### PR DESCRIPTION
Closes #213

## What changed

- Added `RequestBodyBecameEnumBreakingChange` (rule code R021) - a new breaking change type that fires when a request body property or request parameter that previously had no enum constraint gains one.
- Added `RequestBodyBecameEnumRule` - a Spring `@Component` rule that iterates all paths, compares old vs new request body schemas recursively (via `getSchemasRecursively()`), and also checks request parameters, flagging any property whose `enumValues` was empty/null in the old spec and is non-empty in the new spec.
- Added integration test `RequestBodyBecameEnumIntTest` with swagger fixtures where the `status` field on a POST body goes from an unconstrained string to an enum.

## Test plan

- [x] `./gradlew check` passes (Checkstyle + SpotBugs + all tests)
- [x] New integration test covers the happy path: unconstrained property gaining an enum is flagged
- [x] A property that already had an enum gaining more values is NOT flagged by this rule (that case is handled by the existing enum-value-deleted rules)