### PR TITLE
feat(R034): detect response media type generalization

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedBreakingChange.java
@@ -1,0 +1,33 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponseMediaTypeGeneralizedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String oldMediaType;
+    private final String newMediaType;
+
+    @Override
+    public String getMessage() {
+        return format("Response media type %s was generalized to %s at %s %s %s",
+            oldMediaType, newMediaType, method, path, responseCode);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R034";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRule.java
@@ -1,0 +1,85 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponseMediaTypeGeneralizedRule implements BreakingChangeRule<ResponseMediaTypeGeneralizedBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponseMediaTypeGeneralizedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponseMediaTypeGeneralizedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response apiResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(apiResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        checkMediaTypeGeneralized(breakingChanges, path, apiResponse, newResponse);
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+
+    private void checkMediaTypeGeneralized(Set<ResponseMediaTypeGeneralizedBreakingChange> breakingChanges,
+            Path path, Response oldResponse, Response newResponse) {
+        Set<MediaType> newMediaTypes = newResponse.getMediaTypes().keySet();
+        for (Map.Entry<MediaType, Schema> entry : oldResponse.getMediaTypes().entrySet()) {
+            String oldMime = entry.getKey().getMimeType();
+            if (newResponse.isMediaTypeAllowed(entry.getKey())) {
+                continue;
+            }
+            for (MediaType newMediaType : newMediaTypes) {
+                String newMime = newMediaType.getMimeType();
+                if (isGeneralization(oldMime, newMime)) {
+                    breakingChanges.add(new ResponseMediaTypeGeneralizedBreakingChange(
+                        path.getPath(), path.getMethod(), oldResponse.getCode(), oldMime, newMime));
+                    break;
+                }
+            }
+        }
+    }
+
+    private boolean isGeneralization(String oldMime, String newMime) {
+        if (oldMime.endsWith("+json") && "application/json".equals(newMime)) {
+            return true;
+        }
+        if (oldMime.endsWith("+xml") && "application/xml".equals(newMime)) {
+            return true;
+        }
+        if (oldMime.startsWith("application/vnd.")) {
+            if (newMime.startsWith("application/") && newMime.equals("application/*")) {
+                return true;
+            }
+            if ("*/*".equals(newMime)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
@@ -1,0 +1,149 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ResponseMediaTypeGeneralizedRuleTest {
+    private PathSkipper pathSkipper;
+    private ResponseMediaTypeGeneralizedRule underTest;
+
+    @BeforeEach
+    void setUp() {
+        pathSkipper = mock(PathSkipper.class);
+        when(pathSkipper.shouldSkip(any())).thenReturn(false);
+        underTest = new ResponseMediaTypeGeneralizedRule(pathSkipper);
+    }
+
+    @Test
+    void testVendorJsonGeneralizedToApplicationJsonIsDetected() {
+        // given
+        MediaType oldMediaType = new MediaType("application/vnd.api+json");
+        MediaType newMediaType = new MediaType("application/json");
+        Schema schema = mock(Schema.class);
+
+        Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
+        oldMediaTypes.put(oldMediaType, schema);
+        Response oldResponse = new Response("200", oldMediaTypes);
+
+        Map<MediaType, Schema> newMediaTypes = new HashMap<>();
+        newMediaTypes.put(newMediaType, schema);
+        Response newResponse = new Response("200", newMediaTypes);
+
+        Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
+        Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
+
+        Specification oldApi = new Specification(List.of(oldPath));
+        Specification newApi = new Specification(List.of(newPath));
+
+        // when
+        Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).hasSize(1);
+        ResponseMediaTypeGeneralizedBreakingChange bc = result.iterator().next();
+        assertThat(bc.getOldMediaType()).isEqualTo("application/vnd.api+json");
+        assertThat(bc.getNewMediaType()).isEqualTo("application/json");
+        assertThat(bc.getResponseCode()).isEqualTo("200");
+    }
+
+    @Test
+    void testSameMediaTypeIsNotFlagged() {
+        // given
+        MediaType mediaType = new MediaType("application/json");
+        Schema schema = mock(Schema.class);
+
+        Map<MediaType, Schema> mediaTypes = new HashMap<>();
+        mediaTypes.put(mediaType, schema);
+        Response response = new Response("200", mediaTypes);
+
+        Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
+        Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
+
+        Specification oldApi = new Specification(List.of(oldPath));
+        Specification newApi = new Specification(List.of(newPath));
+
+        // when
+        Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testBothOldAndNewTypePresentIsNotFlagged() {
+        // given
+        MediaType oldMediaType = new MediaType("application/vnd.api+json");
+        MediaType newGeneralMediaType = new MediaType("application/json");
+        Schema schema = mock(Schema.class);
+
+        Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
+        oldMediaTypes.put(oldMediaType, schema);
+        Response oldResponse = new Response("200", oldMediaTypes);
+
+        Map<MediaType, Schema> newMediaTypes = new HashMap<>();
+        newMediaTypes.put(oldMediaType, schema);
+        newMediaTypes.put(newGeneralMediaType, schema);
+        Response newResponse = new Response("200", newMediaTypes);
+
+        Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
+        Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
+
+        Specification oldApi = new Specification(List.of(oldPath));
+        Specification newApi = new Specification(List.of(newPath));
+
+        // when
+        Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testVendorXmlGeneralizedToApplicationXmlIsDetected() {
+        // given
+        MediaType oldMediaType = new MediaType("application/vnd.api+xml");
+        MediaType newMediaType = new MediaType("application/xml");
+        Schema schema = mock(Schema.class);
+
+        Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
+        oldMediaTypes.put(oldMediaType, schema);
+        Response oldResponse = new Response("200", oldMediaTypes);
+
+        Map<MediaType, Schema> newMediaTypes = new HashMap<>();
+        newMediaTypes.put(newMediaType, schema);
+        Response newResponse = new Response("200", newMediaTypes);
+
+        Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
+        Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
+
+        Specification oldApi = new Specification(List.of(oldPath));
+        Specification newApi = new Specification(List.of(newPath));
+
+        // when
+        Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).hasSize(1);
+        ResponseMediaTypeGeneralizedBreakingChange bc = result.iterator().next();
+        assertThat(bc.getOldMediaType()).isEqualTo("application/vnd.api+xml");
+        assertThat(bc.getNewMediaType()).isEqualTo("application/xml");
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/response/ResponseMediaTypeGeneralizedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/response/ResponseMediaTypeGeneralizedIntTest.java
@@ -1,0 +1,39 @@
+package com.docktape.swagger.brake.integration.v2.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.rule.response.ResponseMediaTypeDeletedBreakingChange;
+import com.docktape.swagger.brake.core.rule.response.ResponseMediaTypeGeneralizedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponseMediaTypeGeneralizedIntTest extends AbstractSwaggerBrakeIntTest {
+    @Test
+    void testResponseMediaTypeGeneralizedIsDetected() {
+        // given
+        String oldApiPath = "swaggers/v2/response/mediatypegeneralized/petstore.yaml";
+        String newApiPath = "swaggers/v2/response/mediatypegeneralized/petstore_v2.yaml";
+        ResponseMediaTypeGeneralizedBreakingChange generalizedBc = new ResponseMediaTypeGeneralizedBreakingChange(
+            "/pet/findByStatus", HttpMethod.GET, "200", "application/vnd.api+json", "application/json");
+        ResponseMediaTypeDeletedBreakingChange deletedBc = new ResponseMediaTypeDeletedBreakingChange(
+            "/pet/findByStatus", HttpMethod.GET, new MediaType("application/vnd.api+json"));
+        Collection<BreakingChange> expected = List.of(generalizedBc, deletedBc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(2),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/response/mediatypegeneralized/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/response/mediatypegeneralized/petstore.yaml
@@ -1,0 +1,29 @@
+---
+swagger: "2.0"
+info:
+  description: "Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      summary: "Finds Pets by status"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/vnd.api+json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+        400:
+          description: "Invalid status value"

--- a/swagger-brake/src/test/resources/swaggers/v2/response/mediatypegeneralized/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/response/mediatypegeneralized/petstore_v2.yaml
@@ -1,0 +1,29 @@
+---
+swagger: "2.0"
+info:
+  description: "Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      summary: "Finds Pets by status"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+        400:
+          description: "Invalid status value"


### PR DESCRIPTION
Closes #220

## What changed

Added `ResponseMediaTypeGeneralizedRule` (R034) and `ResponseMediaTypeGeneralizedBreakingChange` that detect when a response media type is replaced by a more general parent type.

Examples detected:
- `application/vnd.api+json` replaced by `application/json`
- `application/vnd.api+xml` replaced by `application/xml`
- `application/vnd.*` replaced by `application/*` or `*/*`

This is distinct from R013 (`ResponseMediaTypeDeletedRule`) which only catches complete removal. R034 catches the subtlety where the specific vendor type disappears but a broader parent appears instead - which can break strict content-negotiation clients.

## Test plan

- [x] `./gradlew check` passes (checkstyle + spotbugs + all tests)
- [x] Unit tests: `ResponseMediaTypeGeneralizedRuleTest` covers happy path (vnd+json -> json, vnd+xml -> xml), same-type not flagged, and both-types-present not flagged
- [x] Integration test: `ResponseMediaTypeGeneralizedIntTest` verifies the rule fires end-to-end on real swagger fixtures