### PR TITLE
feat(R025): detect response-side constraint loosening

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedBreakingChange.java
@@ -1,0 +1,35 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ConstraintChange;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponseConstraintChangedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String attributeName;
+    private final ConstraintChange constraintChange;
+
+    @Override
+    public String getMessage() {
+        return format("Response constraint loosened at %s in %s at %s %s: %s was changed from %s to %s",
+            attributeName, responseCode, method, path,
+            constraintChange.getAttribute(), constraintChange.getOldValue(), constraintChange.getNewValue());
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R025";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedRule.java
@@ -1,0 +1,107 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.docktape.swagger.brake.core.model.ArraySchema;
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.NumberSchema;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.model.StringSchema;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ArrayConstrainedValue;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.Constraint;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ConstrainedValue;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.NoConstrainedValue;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.NumberConstrainedValue;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.StringConstrainedValue;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponseConstraintChangedRule implements BreakingChangeRule<ResponseConstraintChangedBreakingChange> {
+    private final Collection<Constraint<?>> constraints;
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponseConstraintChangedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponseConstraintChangedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response oldResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(oldResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        for (Map.Entry<MediaType, Schema> entry : oldResponse.getMediaTypes().entrySet()) {
+                            MediaType mediaType = entry.getKey();
+                            Schema oldSchema = entry.getValue();
+                            Optional<Schema> newApiSchema = newResponse.getSchemaByMediaType(mediaType);
+                            if (newApiSchema.isPresent()) {
+                                Schema newSchema = newApiSchema.get();
+                                Map<String, Schema> oldSchemas = oldSchema.getSchemasRecursively();
+                                Map<String, Schema> newSchemas = newSchema.getSchemasRecursively();
+                                for (Map.Entry<String, Schema> schemaEntry : oldSchemas.entrySet()) {
+                                    Schema newSubSchema = newSchemas.get(schemaEntry.getKey());
+                                    if (newSubSchema != null) {
+                                        breakingChanges.addAll(applyConstraints(path, oldResponse.getCode(),
+                                            fromSchema(schemaEntry.getValue()), fromSchema(newSubSchema), schemaEntry.getKey()));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+
+    private ConstrainedValue fromSchema(Schema schema) {
+        if (schema instanceof ArraySchema) {
+            ArraySchema arSchema = (ArraySchema) schema;
+            return new ArrayConstrainedValue(arSchema.getMaxItems(), arSchema.getMinItems(), arSchema.getUniqueItems());
+        } else if (schema instanceof NumberSchema) {
+            NumberSchema nuSchema = (NumberSchema) schema;
+            return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum());
+        } else if (schema instanceof StringSchema) {
+            StringSchema stSchema = (StringSchema) schema;
+            return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength());
+        } else {
+            return new NoConstrainedValue();
+        }
+    }
+
+    private <T extends ConstrainedValue> Collection<ResponseConstraintChangedBreakingChange> applyConstraints(
+            Path path, String responseCode, T oldValue, T newValue, String attributeName) {
+        Class<T> classType = (Class<T>) oldValue.getClass();
+        Class<T> newClassType = (Class<T>) newValue.getClass();
+        // Swap old/new so that loosening (new has larger max or smaller min) looks like tightening to the constraint impls
+        List<ResponseConstraintChangedBreakingChange> bcs = constraints.stream()
+            .filter(c -> c.handledRequestParameter().equals(classType))
+            .filter(c -> c.handledRequestParameter().equals(newClassType))
+            .map(c -> ((Constraint<T>) c).validateConstraints(newValue, oldValue))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(cc -> new ResponseConstraintChangedBreakingChange(path.getPath(), path.getMethod(), responseCode, attributeName, cc))
+            .collect(Collectors.toList());
+        return bcs;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/response/ResponseConstraintChangedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/response/ResponseConstraintChangedIntTest.java
@@ -1,0 +1,47 @@
+package com.docktape.swagger.brake.integration.v2.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ConstraintChange;
+import com.docktape.swagger.brake.core.rule.response.ResponseConstraintChangedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponseConstraintChangedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testResponseConstraintLooseningIsBreakingChangeWhenMaxLengthIncreases() {
+        // given
+        String oldApiPath = "swaggers/v2/response/constraintloosened/maxlength/swagger-old.json";
+        String newApiPath = "swaggers/v2/response/constraintloosened/maxlength/swagger-new.json";
+        ResponseConstraintChangedBreakingChange expected = new ResponseConstraintChangedBreakingChange(
+            "/store/order/{orderId}", HttpMethod.GET, "200", "status", new ConstraintChange("maxLength", 20, 10));
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(Collections.singletonList(expected))
+        );
+    }
+
+    @Test
+    void testResponseConstraintTighteningIsNotBreakingChangeWhenMaxLengthDecreases() {
+        // given
+        String oldApiPath = "swaggers/v2/response/constrainttightened/maxlength/swagger-old.json";
+        String newApiPath = "swaggers/v2/response/constrainttightened/maxlength/swagger-new.json";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/response/constraintloosened/maxlength/swagger-new.json
+++ b/swagger-brake/src/test/resources/swaggers/v2/response/constraintloosened/maxlength/swagger-new.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/store/order/{orderId}": {
+      "get": {
+        "operationId": "getOrderById",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "maxLength": 20
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/response/constraintloosened/maxlength/swagger-old.json
+++ b/swagger-brake/src/test/resources/swaggers/v2/response/constraintloosened/maxlength/swagger-old.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/store/order/{orderId}": {
+      "get": {
+        "operationId": "getOrderById",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "maxLength": 10
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/response/constrainttightened/maxlength/swagger-new.json
+++ b/swagger-brake/src/test/resources/swaggers/v2/response/constrainttightened/maxlength/swagger-new.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/store/order/{orderId}": {
+      "get": {
+        "operationId": "getOrderById",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "maxLength": 10
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/response/constrainttightened/maxlength/swagger-old.json
+++ b/swagger-brake/src/test/resources/swaggers/v2/response/constrainttightened/maxlength/swagger-old.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/store/order/{orderId}": {
+      "get": {
+        "operationId": "getOrderById",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Order": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "maxLength": 20
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #207

## What changed

Added `ResponseConstraintChangedRule` (rule code **R025**) that detects when response schema constraints are **loosened** between API versions.

Loosening a response constraint is breaking because clients that sized buffers or validated against the old constraint may fail when the server returns a wider value:
- `maxLength` increases
- `minItems` decreases
- `maximum` increases
- `minimum` decreases

### Implementation approach

The existing `Constraint` implementations already know how to detect **tightening** (they flag when new is more restrictive than old). For responses, we need to detect the opposite direction. The rule re-uses all existing `Constraint` implementations by swapping old/new when calling `validateConstraints` - this makes loosening appear as tightening to the validator.

New files:
- `ResponseConstraintChangedBreakingChange` - the breaking change record, rule code R025
- `ResponseConstraintChangedRule` - the Spring `@Component` rule, injected alongside all `Constraint<?>` beans

## Test plan

- [x] `./gradlew check` passes (checkstyle + spotbugs + all tests)
- [x] `testResponseConstraintLooseningIsBreakingChangeWhenMaxLengthIncreases` - flags maxLength 10 -> 20 on response as R025
- [x] `testResponseConstraintTighteningIsNotBreakingChangeWhenMaxLengthDecreases` - maxLength 20 -> 10 on response is NOT flagged (not a client-breaking change)