### PR TITLE
feat(output): add Markdown output format

### DIFF
--- a/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandlerTest.java
+++ b/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandlerTest.java
@@ -99,4 +99,14 @@ class OutputFormatsHandlerTest {
         // then
         assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.GITHUB_ACTIONS));
     }
+
+    @Test
+    void testHandleShouldSetFormatToMarkdownWhenPropertyValueIsMarkdown() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("markdown", options);
+        // then
+        assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.MARKDOWN));
+    }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/report/MarkdownReporter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/report/MarkdownReporter.java
@@ -1,0 +1,63 @@
+package com.docktape.swagger.brake.report;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import com.docktape.swagger.brake.core.ApiInfo;
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.report.file.DirectoryCreator;
+import com.docktape.swagger.brake.report.file.FileWriter;
+import com.docktape.swagger.brake.runner.OutputFormat;
+import java.util.Collection;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+class MarkdownReporter extends AbstractFileReporter implements CheckableReporter {
+    private static final String DEFAULT_FILENAME = "swagger-brake.md";
+    private static final String VERSIONED_FILENAME_TEMPLATE = "swagger-brake-%s.md";
+
+    public MarkdownReporter(FileWriter fileWriter, DirectoryCreator directoryCreator) {
+        super(fileWriter, directoryCreator);
+    }
+
+    @Override
+    protected String getFilename(ApiInfo apiInfo) {
+        String result = DEFAULT_FILENAME;
+        if (apiInfo != null && isNotBlank(apiInfo.getVersion())) {
+            result = VERSIONED_FILENAME_TEMPLATE.formatted(apiInfo.getVersion());
+        }
+        return result;
+    }
+
+    @Override
+    protected String toFileContent(Collection<BreakingChange> breakingChanges, Collection<BreakingChange> ignoredBreakingChanges, ApiInfo apiInfo) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("# swagger-brake Report\n\n");
+        appendSection(sb, "Breaking Changes", breakingChanges);
+        sb.append("\n");
+        appendSection(sb, "Ignored Breaking Changes", ignoredBreakingChanges);
+        return sb.toString();
+    }
+
+    private void appendSection(StringBuilder sb, String title, Collection<BreakingChange> breakingChanges) {
+        sb.append("## ").append(title).append(" (").append(breakingChanges.size()).append(")\n");
+        sb.append("| Rule | Message |\n");
+        sb.append("|------|---------|\n");
+        for (BreakingChange bc : breakingChanges) {
+            sb.append("| ").append(escape(bc.getRuleCode())).append(" | ").append(escape(bc.getMessage())).append(" |\n");
+        }
+    }
+
+    private String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("|", "\\|");
+    }
+
+    @Override
+    public boolean canReport(OutputFormat format) {
+        return OutputFormat.MARKDOWN.equals(format);
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/OutputFormat.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/OutputFormat.java
@@ -4,5 +4,6 @@ public enum OutputFormat {
     STDOUT,
     JSON,
     HTML,
-    GITHUB_ACTIONS
+    GITHUB_ACTIONS,
+    MARKDOWN
 }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
@@ -41,11 +41,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -72,7 +72,7 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> mediaTypes = new HashMap<>();
         mediaTypes.put(mediaType, schema);
-        Response response = new Response("200", mediaTypes);
+        Response response = new Response("200", mediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
@@ -96,12 +96,12 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(oldMediaType, schema);
         newMediaTypes.put(newGeneralMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -125,11 +125,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/report/MarkdownReporterTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/report/MarkdownReporterTest.java
@@ -1,0 +1,158 @@
+package com.docktape.swagger.brake.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.report.file.DirectoryCreator;
+import com.docktape.swagger.brake.report.file.FileWriter;
+import com.docktape.swagger.brake.runner.Options;
+import com.docktape.swagger.brake.runner.OutputFormat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MarkdownReporterTest {
+
+    @Mock
+    private FileWriter fileWriter;
+
+    @Mock
+    private DirectoryCreator directoryCreator;
+
+    @InjectMocks
+    private MarkdownReporter underTest;
+
+    @Test
+    void testCanReportShouldReturnTrueIfOutputFormatIsMarkdown() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.MARKDOWN);
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseIfOutputFormatIsJson() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.JSON);
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseIfOutputFormatIsHtml() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.HTML);
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testReportShouldWriteMarkdownFileWithBreakingChanges() throws IOException {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        given(bc.getRuleCode()).willReturn("R004");
+        given(bc.getMessage()).willReturn("parameter X deleted at GET /foo");
+
+        Collection<BreakingChange> breakingChanges = Collections.singletonList(bc);
+
+        String outputFilePath = "outputFilePath";
+        Options options = new Options();
+        options.setOutputFilePath(outputFilePath);
+
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        // when
+        underTest.report(breakingChanges, options);
+        // then
+        then(directoryCreator).should().create(outputFilePath);
+        then(fileWriter).should().write(eq(outputFilePath + File.separator + "swagger-brake.md"), contentCaptor.capture());
+        String content = contentCaptor.getValue();
+        assertThat(content).contains("# swagger-brake Report");
+        assertThat(content).contains("## Breaking Changes (1)");
+        assertThat(content).contains("| R004 | parameter X deleted at GET /foo |");
+        assertThat(content).contains("## Ignored Breaking Changes (0)");
+    }
+
+    @Test
+    void testReportShouldWriteMarkdownFileWithNoBreakingChanges() throws IOException {
+        // given
+        Collection<BreakingChange> breakingChanges = Collections.emptyList();
+
+        String outputFilePath = "outputFilePath";
+        Options options = new Options();
+        options.setOutputFilePath(outputFilePath);
+
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        // when
+        underTest.report(breakingChanges, options);
+        // then
+        then(fileWriter).should().write(anyString(), contentCaptor.capture());
+        String content = contentCaptor.getValue();
+        assertThat(content).contains("## Breaking Changes (0)");
+        assertThat(content).doesNotContain("R0");
+    }
+
+    @Test
+    void testReportShouldEscapePipeCharactersInMessages() throws IOException {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        given(bc.getRuleCode()).willReturn("R010");
+        given(bc.getMessage()).willReturn("value changed from a|b to c|d");
+
+        Collection<BreakingChange> breakingChanges = Collections.singletonList(bc);
+
+        String outputFilePath = "outputFilePath";
+        Options options = new Options();
+        options.setOutputFilePath(outputFilePath);
+
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        // when
+        underTest.report(breakingChanges, options);
+        // then
+        then(fileWriter).should().write(anyString(), contentCaptor.capture());
+        String content = contentCaptor.getValue();
+        assertThat(content).contains("value changed from a\\|b to c\\|d");
+    }
+
+    @Test
+    void testReportShouldWriteIgnoredBreakingChangesSection() throws IOException {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        given(bc.getRuleCode()).willReturn("R001");
+        given(bc.getMessage()).willReturn("some ignored change");
+
+        Collection<BreakingChange> breakingChanges = Collections.emptyList();
+        List<BreakingChange> ignoredBreakingChanges = Collections.singletonList(bc);
+
+        String outputFilePath = "outputFilePath";
+        Options options = new Options();
+        options.setOutputFilePath(outputFilePath);
+
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        // when
+        underTest.report(breakingChanges, ignoredBreakingChanges, options, null);
+        // then
+        then(fileWriter).should().write(anyString(), contentCaptor.capture());
+        String content = contentCaptor.getValue();
+        assertThat(content).contains("## Breaking Changes (0)");
+        assertThat(content).contains("## Ignored Breaking Changes (1)");
+        assertThat(content).contains("| R001 | some ignored change |");
+    }
+}


### PR DESCRIPTION
Closes #231

## What changed

- Added `MARKDOWN` to `OutputFormat` enum
- Implemented `MarkdownReporter` that generates a GitHub Flavored Markdown report with two sections: Breaking Changes and Ignored Breaking Changes, each rendered as a pipe table with Rule and Message columns
- Pipe characters in messages are escaped (`|` -> `\|`) to avoid breaking the table structure
- The reporter follows the same `AbstractFileReporter` + `CheckableReporter` pattern as `HtmlReporter` and `JsonReporter`
- Default filename: `swagger-brake.md`; versioned filename when `ApiInfo.version` is set
- The CLI handler already maps `"markdown"` -> `MARKDOWN` via `String::toUpperCase` + `OutputFormat::valueOf`, so no changes to `OutputFormatsHandler` were needed beyond adding the test

## Test plan

- [x] `./gradlew check` passes (all 7 new MarkdownReporter tests + 1 new OutputFormatsHandler test green)
- [x] Happy path: breaking changes produce correct GFM table rows
- [x] Edge case: empty breaking changes produces table with 0 entries
- [x] Pipe characters in messages are escaped
- [x] Ignored breaking changes section is populated correctly
- [x] `canReport(MARKDOWN)` returns true; other formats return false