### PR TITLE
feat(R027/R028): detect nullable transitions on request and response properties

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
@@ -192,6 +192,20 @@ public class Schema {
     }
 
     /**
+     * Returns a map of attribute name to nullable flag for all attributes recursively.
+     * @return the nullable attribute map.
+     */
+    public Map<String, Boolean> getNullableAttributes() {
+        Collection<SchemaAttribute> schemaAttrs = schemaAttributes;
+        if (CollectionUtils.isEmpty(schemaAttrs)) {
+            schemaAttrs = Optional.ofNullable(schema).map(Schema::getSchemaAttributes).orElse(Collections.emptySet());
+        }
+        return internalGetAttributeData(schemaAttrs, "", SchemaAttribute::isNullable)
+            .stream()
+            .collect(toMap(Pair::getLeft, Pair::getRight, (a, b) -> a));
+    }
+
+    /**
      * Returns the schemas with attribute names recursively.
      * @return the schemas recursively
      */

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaAttribute.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaAttribute.java
@@ -14,6 +14,7 @@ public class SchemaAttribute implements Comparable<SchemaAttribute> {
     private final Schema schema;
     private final boolean required;
     private final boolean deprecated;
+    private final boolean nullable;
 
     public String getName() {
         return name.replace(Schema.LEVEL_DELIMITER_REPLACE_VALUE, Schema.LEVEL_DELIMITER);

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import static java.util.stream.Collectors.toSet;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import org.springframework.stereotype.Component;
@@ -199,7 +200,8 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
                 Boolean deprecatedInSchema = newInternalSchema.getDeprecated();
                 boolean deprecated = deprecatedInSchema == null ? false : deprecatedInSchema;
                 boolean required = requiredAttributes.contains(attributeName);
-                result.add(new SchemaAttribute(attributeName, schema, required, deprecated));
+                boolean nullable = BooleanUtils.isTrue(newInternalSchema.getNullable());
+                result.add(new SchemaAttribute(attributeName, schema, required, deprecated, nullable));
             } finally {
                 SchemaTransformationContext.exitSchema(newInternalSchema);
             }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyBecameNonNullableBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyBecameNonNullableBreakingChange.java
@@ -1,0 +1,30 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestPropertyBecameNonNullableBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String propertyName;
+
+    @Override
+    public String getMessage() {
+        return format("%s became non-nullable at %s %s", propertyName, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R027";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyBecameNonNullableRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyBecameNonNullableRule.java
@@ -1,0 +1,64 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Request;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestPropertyBecameNonNullableRule implements BreakingChangeRule<RequestPropertyBecameNonNullableBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestPropertyBecameNonNullableBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestPropertyBecameNonNullableBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                Optional<Request> requestBody = path.getRequestBody();
+                Optional<Request> newRequestBody = newPath.getRequestBody();
+                if (requestBody.isPresent() && newRequestBody.isPresent()) {
+                    for (Map.Entry<MediaType, Schema> entry : requestBody.get().getMediaTypes().entrySet()) {
+                        MediaType mediaType = entry.getKey();
+                        Schema schema = entry.getValue();
+                        Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
+                        if (newApiSchema.isPresent()) {
+                            Schema newSchema = newApiSchema.get();
+                            Map<String, Boolean> oldNullable = schema.getNullableAttributes();
+                            Map<String, Boolean> newNullable = newSchema.getNullableAttributes();
+                            for (Map.Entry<String, Boolean> nullableEntry : oldNullable.entrySet()) {
+                                String attrName = nullableEntry.getKey();
+                                boolean wasNullable = Boolean.TRUE.equals(nullableEntry.getValue());
+                                boolean isNullable = Boolean.TRUE.equals(newNullable.get(attrName));
+                                if (wasNullable && !isNullable) {
+                                    breakingChanges.add(
+                                        new RequestPropertyBecameNonNullableBreakingChange(path.getPath(), path.getMethod(), attrName));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameNullableBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameNullableBreakingChange.java
@@ -1,0 +1,31 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponsePropertyBecameNullableBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String propertyName;
+
+    @Override
+    public String getMessage() {
+        return format("%s in %s became nullable at %s %s", propertyName, responseCode, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R028";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameNullableRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameNullableRule.java
@@ -1,0 +1,67 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponsePropertyBecameNullableRule implements BreakingChangeRule<ResponsePropertyBecameNullableBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponsePropertyBecameNullableBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponsePropertyBecameNullableBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response apiResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(apiResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        for (Map.Entry<MediaType, Schema> entry : apiResponse.getMediaTypes().entrySet()) {
+                            MediaType mediaType = entry.getKey();
+                            Schema schema = entry.getValue();
+                            Optional<Schema> newApiSchema = newResponse.getSchemaByMediaType(mediaType);
+                            if (newApiSchema.isPresent()) {
+                                Schema newSchema = newApiSchema.get();
+                                Map<String, Boolean> oldNullable = schema.getNullableAttributes();
+                                Map<String, Boolean> newNullable = newSchema.getNullableAttributes();
+                                for (Map.Entry<String, Boolean> nullableEntry : oldNullable.entrySet()) {
+                                    String attrName = nullableEntry.getKey();
+                                    boolean wasNullable = Boolean.TRUE.equals(nullableEntry.getValue());
+                                    boolean isNullable = Boolean.TRUE.equals(newNullable.get(attrName));
+                                    if (!wasNullable && isNullable) {
+                                        breakingChanges.add(
+                                            new ResponsePropertyBecameNullableBreakingChange(
+                                                path.getPath(), path.getMethod(), apiResponse.getCode(), attrName));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformerTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformerTest.java
@@ -64,10 +64,10 @@ class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("bark", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("bark", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));
@@ -100,9 +100,9 @@ class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));
@@ -143,10 +143,10 @@ class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef, catRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false, false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false, false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));
@@ -187,10 +187,10 @@ class SchemaTransformerTest {
         composedSchema.setAllOf(ImmutableList.of(petRef, dogRef, catRef));
 
         Schema expectedSchema = new SchemaBuilder("object").schemaAttributes(ImmutableList.of(
-            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false),
-            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false),
-            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false, false)
+            new SchemaAttribute("id", new SchemaBuilder("integer").build(), false, false, false),
+            new SchemaAttribute("name", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("breed", new SchemaBuilder("string").build(), false, false, false),
+            new SchemaAttribute("meow", new SchemaBuilder("string").build(), false, false, false)
         )).build();
         // when
         Schema result = withSchemaStore(schemaStore, () -> underTest.transform(composedSchema));

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/nullabletransition/RequestPropertyBecameNonNullableIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/nullabletransition/RequestPropertyBecameNonNullableIntTest.java
@@ -1,0 +1,41 @@
+package com.docktape.swagger.brake.integration.v3.request.nullabletransition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestPropertyBecameNonNullableBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RequestPropertyBecameNonNullableIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testRequestPropertyBecameNonNullableIsBreakingChange() {
+        // given - old spec has nullable: true, new spec removes nullable
+        String oldApiPath = "swaggers/v3/request/nullabletransition/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/nullabletransition/petstore_v2.yaml";
+        RequestPropertyBecameNonNullableBreakingChange expected = new RequestPropertyBecameNonNullableBreakingChange("/pet", HttpMethod.POST, "name");
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).contains(expected);
+    }
+
+    @Test
+    void testRequestPropertyBecameNullableIsNotBreakingChange() {
+        // given - old spec has no nullable, new spec adds nullable: true (reverse direction is not breaking for requests)
+        String oldApiPath = "swaggers/v3/request/nullabletransition/petstore_v2.yaml";
+        String newApiPath = "swaggers/v3/request/nullabletransition/petstore.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/response/nullabletransition/ResponsePropertyBecameNullableIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/response/nullabletransition/ResponsePropertyBecameNullableIntTest.java
@@ -1,0 +1,42 @@
+package com.docktape.swagger.brake.integration.v3.response.nullabletransition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.response.ResponsePropertyBecameNullableBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponsePropertyBecameNullableIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testResponsePropertyBecameNullableIsBreakingChange() {
+        // given - old spec has no nullable, new spec adds nullable: true
+        String oldApiPath = "swaggers/v3/response/nullabletransition/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/nullabletransition/petstore_v2.yaml";
+        ResponsePropertyBecameNullableBreakingChange expected =
+            new ResponsePropertyBecameNullableBreakingChange("/pet", HttpMethod.GET, "200", "name");
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).contains(expected);
+    }
+
+    @Test
+    void testResponsePropertyBecameNonNullableIsNotBreakingChange() {
+        // given - old spec has nullable: true, new spec removes nullable (reverse direction is not breaking for responses)
+        String oldApiPath = "swaggers/v3/response/nullabletransition/petstore_v2.yaml";
+        String newApiPath = "swaggers/v3/response/nullabletransition/petstore.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/request/nullabletransition/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/nullabletransition/petstore.yaml
@@ -1,0 +1,31 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        age:
+          type: integer

--- a/swagger-brake/src/test/resources/swaggers/v3/request/nullabletransition/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/nullabletransition/petstore_v2.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer

--- a/swagger-brake/src/test/resources/swaggers/v3/response/nullabletransition/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/nullabletransition/petstore.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer

--- a/swagger-brake/src/test/resources/swaggers/v3/response/nullabletransition/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/nullabletransition/petstore_v2.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        age:
+          type: integer


### PR DESCRIPTION
Closes #210

## What changed

- Added `nullable` field to `SchemaAttribute`, populated from `schema.getNullable()` via `BooleanUtils.isTrue()` during schema transformation (OpenAPI 3.0 `nullable: true` flag).
- Added `getNullableAttributes()` method to `Schema` that returns a `Map<String, Boolean>` of attribute names to their nullable flag, traversed recursively.
- **R027** (`RequestPropertyBecameNonNullableRule`): flags a breaking change when a request body property transitions from `nullable: true` to non-nullable. Clients that were sending `null` for that field will now be rejected.
- **R028** (`ResponsePropertyBecameNullableRule`): flags a breaking change when a response property transitions from non-nullable to `nullable: true`. Clients that assumed the field is never `null` now have to handle `null`.
- Integration tests and OpenAPI 3.0 YAML fixtures covering both the breaking direction and the non-breaking reverse direction for each rule.

## Test plan

- [x] `./gradlew :swagger-brake:check` passes (checkstyle + spotbugs + all tests)
- [x] R027: request property `nullable: true` -> not nullable is flagged
- [x] R027 inverse: request property not nullable -> `nullable: true` is not flagged
- [x] R028: response property not nullable -> `nullable: true` is flagged
- [x] R028 inverse: response property `nullable: true` -> not nullable is not flagged