### PR TITLE
feat(R029): detect additionalProperties tightening on request schemas

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ArraySchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ArraySchema.java
@@ -27,7 +27,7 @@ public class ArraySchema extends Schema {
      */
     public ArraySchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes,
             Schema schema, Integer maxItems, Integer minItems, Boolean uniqueItems, String constValue) {
-        super(type, enumValues, schemaAttributes, schema, null, constValue);
+        super(type, enumValues, schemaAttributes, schema, null, constValue, null);
         this.maxItems = maxItems;
         this.minItems = minItems;
         this.uniqueItems = uniqueItems;

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
@@ -14,7 +14,7 @@ public class NumberSchema extends Schema {
     private final BigDecimal maximum;
     private final BigDecimal minimum;
     private final BigDecimal multipleOf;
-    
+
     /**
      * Deprecated: Use {@link #exclusiveMaximumValue} instead.
      *
@@ -23,7 +23,7 @@ public class NumberSchema extends Schema {
      */
     @Deprecated
     private final boolean exclusiveMaximum;
-    
+
     /**
      * Deprecated: Use {@link #exclusiveMinimumValue} instead.
      *
@@ -32,13 +32,13 @@ public class NumberSchema extends Schema {
      */
     @Deprecated
     private final boolean exclusiveMinimum;
-    
+
     /**
      * The exclusive maximum value constraint (OpenAPI 3.1.x / JSON Schema Draft 2020-12).
      * If non-null, the value must be strictly less than this number.
      */
     private final BigDecimal exclusiveMaximumValue;
-    
+
     /**
      * The exclusive minimum value constraint (OpenAPI 3.1.x / JSON Schema Draft 2020-12).
      * If non-null, the value must be strictly greater than this number.
@@ -60,7 +60,7 @@ public class NumberSchema extends Schema {
     @Deprecated
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, boolean exclusiveMaximum, boolean exclusiveMinimum) {
-        super(type, enumValues, schemaAttributes, schema, null, null);
+        super(type, enumValues, schemaAttributes, schema, null, null, null);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximum = exclusiveMaximum;
@@ -102,7 +102,7 @@ public class NumberSchema extends Schema {
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, BigDecimal exclusiveMaximumValue, BigDecimal exclusiveMinimumValue,
                         BigDecimal multipleOf) {
-        super(type, enumValues, schemaAttributes, schema, null, null);
+        super(type, enumValues, schemaAttributes, schema, null, null, null);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximumValue = exclusiveMaximumValue;

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -21,7 +20,6 @@ import org.springframework.util.CollectionUtils;
 @Getter
 @EqualsAndHashCode
 @ToString
-@RequiredArgsConstructor
 public class Schema {
     public static final String LEVEL_DELIMITER_REPLACE_VALUE = "$";
     public static final String LEVEL_DELIMITER = ".";
@@ -31,6 +29,66 @@ public class Schema {
     private final Schema schema;
     private final Set<String> extensibleEnum;
     private final String constValue;
+    private final Boolean additionalPropertiesAllowed;
+
+    /**
+     * Constructs a Schema without extensibleEnum, constValue or additionalPropertiesAllowed.
+     * @param type the type
+     * @param enumValues the enum values
+     * @param schemaAttributes the schema attributes
+     * @param schema the nested schema
+     */
+    public Schema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema) {
+        this(type, enumValues, schemaAttributes, schema, null, null, null);
+    }
+
+    /**
+     * Constructs a Schema with extensibleEnum values.
+     * @param type the type
+     * @param enumValues the enum values
+     * @param schemaAttributes the schema attributes
+     * @param schema the nested schema
+     * @param extensibleEnum the x-extensible-enum values
+     */
+    public Schema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
+                  Set<String> extensibleEnum) {
+        this(type, enumValues, schemaAttributes, schema, extensibleEnum, null, null);
+    }
+
+    /**
+     * Constructs a Schema with extensibleEnum and constValue.
+     * @param type the type
+     * @param enumValues the enum values
+     * @param schemaAttributes the schema attributes
+     * @param schema the nested schema
+     * @param extensibleEnum the x-extensible-enum values
+     * @param constValue the const value (nullable)
+     */
+    public Schema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
+                  Set<String> extensibleEnum, String constValue) {
+        this(type, enumValues, schemaAttributes, schema, extensibleEnum, constValue, null);
+    }
+
+    /**
+     * Constructs a Schema with all fields.
+     * @param type the type
+     * @param enumValues the enum values
+     * @param schemaAttributes the schema attributes
+     * @param schema the nested schema
+     * @param extensibleEnum the x-extensible-enum values
+     * @param constValue the const value (nullable)
+     * @param additionalPropertiesAllowed null means unspecified (treated as allowed), true means allowed, false means disallowed
+     */
+    public Schema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
+                  Set<String> extensibleEnum, String constValue, Boolean additionalPropertiesAllowed) {
+        this.type = type;
+        this.enumValues = enumValues;
+        this.schemaAttributes = schemaAttributes;
+        this.schema = schema;
+        this.extensibleEnum = extensibleEnum;
+        this.constValue = constValue;
+        this.additionalPropertiesAllowed = additionalPropertiesAllowed;
+    }
 
     public Optional<Schema> getSchema() {
         return Optional.ofNullable(schema);

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
@@ -43,6 +43,7 @@ public class SchemaBuilder {
     private Set<String> extensibleEnum;
     private BigDecimal multipleOf;
     private String constValue;
+    private Boolean additionalPropertiesAllowed;
 
     public SchemaBuilder(String type) {
         this.type = type;
@@ -182,6 +183,16 @@ public class SchemaBuilder {
     }
 
     /**
+     * Sets whether additional properties are allowed.
+     * @param additionalPropertiesAllowed null means unspecified (treated as allowed), true means allowed, false means disallowed
+     * @return this builder
+     */
+    public SchemaBuilder additionalPropertiesAllowed(Boolean additionalPropertiesAllowed) {
+        this.additionalPropertiesAllowed = additionalPropertiesAllowed;
+        return this;
+    }
+
+    /**
      * Builds a {@link Schema} instance.
      * @return the constructed {@link Schema} instance.
      */
@@ -220,7 +231,7 @@ public class SchemaBuilder {
         } else if (AttributeType.getArrayTypes().contains(attributeType)) {
             return new ArraySchema(type, enumValues, schemaAttributes, schema, maxItems, minItems, uniqueItems, constValue);
         } else {
-            return new Schema(type, enumValues, schemaAttributes, schema, extensibleEnum, constValue);
+            return new Schema(type, enumValues, schemaAttributes, schema, extensibleEnum, constValue, additionalPropertiesAllowed);
         }
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -176,6 +176,14 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
         if (constObj != null) {
             schemaBuilder.constValue(constObj.toString());
         }
+        Object additionalProperties = swSchema.getAdditionalProperties();
+        if (additionalProperties instanceof Boolean) {
+            schemaBuilder.additionalPropertiesAllowed((Boolean) additionalProperties);
+        } else if (additionalProperties instanceof io.swagger.v3.oas.models.media.Schema) {
+            // A schema as additionalProperties means additional properties are allowed (just constrained)
+            schemaBuilder.additionalPropertiesAllowed(Boolean.TRUE);
+        }
+        // null means unspecified, leave additionalPropertiesAllowed as null
         return schemaBuilder.build();
     }
 

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestAdditionalPropertiesTightenedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestAdditionalPropertiesTightenedBreakingChange.java
@@ -1,0 +1,28 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestAdditionalPropertiesTightenedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String schemaPath;
+
+    @Override
+    public String getMessage() {
+        return String.format("additionalProperties was tightened at %s in %s %s", schemaPath, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R029";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestAdditionalPropertiesTightenedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestAdditionalPropertiesTightenedRule.java
@@ -1,0 +1,79 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Request;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestAdditionalPropertiesTightenedRule
+        implements BreakingChangeRule<RequestAdditionalPropertiesTightenedBreakingChange> {
+
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestAdditionalPropertiesTightenedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestAdditionalPropertiesTightenedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                Optional<Request> requestBody = path.getRequestBody();
+                Optional<Request> newRequestBody = newPath.getRequestBody();
+                if (requestBody.isPresent() && newRequestBody.isPresent()) {
+                    for (Map.Entry<MediaType, Schema> entry : requestBody.get().getMediaTypes().entrySet()) {
+                        MediaType mediaType = entry.getKey();
+                        Schema oldSchema = entry.getValue();
+                        Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
+                        if (newApiSchema.isPresent()) {
+                            Schema newSchema = newApiSchema.get();
+                            checkSchemasRecursively(path.getPath(), path.getMethod(), oldSchema, newSchema, breakingChanges);
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+
+    private void checkSchemasRecursively(String pathStr, com.docktape.swagger.brake.core.model.HttpMethod method,
+                                         Schema oldSchema, Schema newSchema,
+                                         Set<RequestAdditionalPropertiesTightenedBreakingChange> breakingChanges) {
+        Map<String, Schema> oldSchemas = oldSchema.getSchemasRecursively();
+        Map<String, Schema> newSchemas = newSchema.getSchemasRecursively();
+        for (Map.Entry<String, Schema> entry : oldSchemas.entrySet()) {
+            String schemaPath = entry.getKey();
+            Schema oldSubSchema = entry.getValue();
+            Schema newSubSchema = newSchemas.get(schemaPath);
+            if (newSubSchema == null) {
+                continue;
+            }
+            Boolean oldAllowed = oldSubSchema.getAdditionalPropertiesAllowed();
+            Boolean newAllowed = newSubSchema.getAdditionalPropertiesAllowed();
+            // Breaking if old was null (unspecified, treated as allowed) or true, and new is false
+            boolean oldWasAllowed = !Boolean.FALSE.equals(oldAllowed);
+            boolean newIsDisallowed = Boolean.FALSE.equals(newAllowed);
+            if (oldWasAllowed && newIsDisallowed) {
+                breakingChanges.add(new RequestAdditionalPropertiesTightenedBreakingChange(pathStr, method, schemaPath));
+            }
+        }
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/additionalpropertiestightened/RequestAdditionalPropertiesTightenedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/additionalpropertiestightened/RequestAdditionalPropertiesTightenedIntTest.java
@@ -1,0 +1,62 @@
+package com.docktape.swagger.brake.integration.v3.request.additionalpropertiestightened;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestAdditionalPropertiesTightenedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RequestAdditionalPropertiesTightenedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testAdditionalPropertiesTrueToFalseIsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/additionalpropertiestightened/petstore_true_to_false.yaml";
+        String newApiPath = "swaggers/v3/request/additionalpropertiestightened/petstore_true_to_false_v2.yaml";
+        RequestAdditionalPropertiesTightenedBreakingChange expected =
+                new RequestAdditionalPropertiesTightenedBreakingChange("/pet", HttpMethod.POST, "");
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result).hasSameElementsAs(List.of(expected))
+        );
+    }
+
+    @Test
+    void testAdditionalPropertiesAbsentToFalseIsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/additionalpropertiestightened/petstore_absent_to_false.yaml";
+        String newApiPath = "swaggers/v3/request/additionalpropertiestightened/petstore_absent_to_false_v2.yaml";
+        RequestAdditionalPropertiesTightenedBreakingChange expected =
+                new RequestAdditionalPropertiesTightenedBreakingChange("/pet", HttpMethod.POST, "");
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result).hasSameElementsAs(List.of(expected))
+        );
+    }
+
+    @Test
+    void testAdditionalPropertiesFalseToFalseIsNotBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/additionalpropertiestightened/petstore_false_to_false.yaml";
+        String newApiPath = "swaggers/v3/request/additionalpropertiestightened/petstore_false_to_false_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_absent_to_false.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_absent_to_false.yaml
@@ -1,0 +1,28 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_absent_to_false_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_absent_to_false_v2.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_false_to_false.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_false_to_false.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_false_to_false_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_false_to_false_v2.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_true_to_false.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_true_to_false.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      additionalProperties: true
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_true_to_false_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/additionalpropertiestightened/petstore_true_to_false_v2.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a pet
+      operationId: addPet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Null response
+components:
+  schemas:
+    Pet:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
Closes #203

## What changed

- Added `additionalPropertiesAllowed` field (`Boolean`) to `Schema` - `null` means unspecified (treated as allowed), `true` means explicitly allowed, `false` means disallowed
- Updated `SchemaBuilder` with a new `additionalPropertiesAllowed(Boolean)` builder method
- Updated `SchemaTransformer.transformSchema()` to populate `additionalPropertiesAllowed` from the swagger-parser `getAdditionalProperties()` result: `Boolean false` -> `false`, `Boolean true` or a `Schema` -> `true`, `null` -> `null`
- Added `RequestAdditionalPropertiesTightenedBreakingChange` (rule code R029) with message: `additionalProperties was tightened at {schemaPath} in {method} {path}`
- Added `RequestAdditionalPropertiesTightenedRule` that iterates all path/request body schema pairs and flags any schema (root or nested) where `additionalProperties` changed from allowed/unspecified to `false`

## Test plan

- [x] `./gradlew :swagger-brake:check` passes (checkstyle + spotbugs + tests)
- [x] `additionalProperties: true` -> `false` on request body root is flagged
- [x] `additionalProperties` absent -> `false` is flagged (absent is treated as allowed)
- [x] `additionalProperties: false` -> `false` is not flagged (no change)