### PR TITLE
feat(output): add GitHub Actions annotations output format

### DIFF
--- a/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandler.java
+++ b/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandler.java
@@ -6,8 +6,10 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.docktape.swagger.brake.cli.options.CliOption;
 import com.docktape.swagger.brake.runner.Options;
@@ -19,6 +21,10 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class OutputFormatsHandler implements CliOptionHandler {
+    private static final Map<String, String> FORMAT_ALIASES = ImmutableMap.of(
+        "GITHUBACTIONS", "GITHUB_ACTIONS"
+    );
+
     @Override
     public void handle(String optionValue, Options options) {
         Set<OutputFormat> formats = ImmutableSet.of(OutputFormat.STDOUT);
@@ -26,7 +32,8 @@ public class OutputFormatsHandler implements CliOptionHandler {
         if (!StringUtils.isBlank(optionValue)) {
             try {
                 String[] formatStrings = optionValue.split(",");
-                formats = Arrays.stream(formatStrings).map(String::trim).map(String::toUpperCase).map(OutputFormat::valueOf).collect(toSet());
+                formats = Arrays.stream(formatStrings).map(String::trim).map(String::toUpperCase)
+                    .map(s -> FORMAT_ALIASES.getOrDefault(s, s)).map(OutputFormat::valueOf).collect(toSet());
             } catch (IllegalArgumentException e) {
                 log.debug("Format cannot be resolved", e);
             }

--- a/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandlerTest.java
+++ b/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandlerTest.java
@@ -79,4 +79,24 @@ class OutputFormatsHandlerTest {
         // then
         assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.HTML, OutputFormat.JSON));
     }
+
+    @Test
+    void testHandleShouldSetFormatToGitHubActionsWhenPropertyValueIsGithubactions() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("githubactions", options);
+        // then
+        assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.GITHUB_ACTIONS));
+    }
+
+    @Test
+    void testHandleShouldSetFormatToGitHubActionsWhenPropertyValueIsGithubActionsWithUnderscore() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("github_actions", options);
+        // then
+        assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.GITHUB_ACTIONS));
+    }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/report/GitHubActionsReporter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/report/GitHubActionsReporter.java
@@ -1,0 +1,23 @@
+package com.docktape.swagger.brake.report;
+
+import com.docktape.swagger.brake.core.ApiInfo;
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.runner.Options;
+import com.docktape.swagger.brake.runner.OutputFormat;
+import java.util.Collection;
+import org.springframework.stereotype.Component;
+
+@Component
+class GitHubActionsReporter implements Reporter, CheckableReporter {
+    @Override
+    public void report(Collection<BreakingChange> breakingChanges, Collection<BreakingChange> ignoredBreakingChanges, Options options, ApiInfo apiInfo) {
+        breakingChanges.forEach(bc ->
+            System.out.println("::error title=Breaking Change (" + bc.getRuleCode() + ")::" + bc.getMessage())
+        );
+    }
+
+    @Override
+    public boolean canReport(OutputFormat format) {
+        return OutputFormat.GITHUB_ACTIONS.equals(format);
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/OutputFormat.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/OutputFormat.java
@@ -3,5 +3,6 @@ package com.docktape.swagger.brake.runner;
 public enum OutputFormat {
     STDOUT,
     JSON,
-    HTML
+    HTML,
+    GITHUB_ACTIONS
 }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/report/GitHubActionsReporterTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/report/GitHubActionsReporterTest.java
@@ -1,0 +1,101 @@
+package com.docktape.swagger.brake.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.runner.Options;
+import com.docktape.swagger.brake.runner.OutputFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GitHubActionsReporterTest {
+    private final GitHubActionsReporter underTest = new GitHubActionsReporter();
+    private final ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
+    private PrintStream originalOut;
+
+    @BeforeEach
+    void setUp() {
+        originalOut = System.out;
+        System.setOut(new PrintStream(capturedOut, false, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void testReportShouldPrintAnnotationForEachBreakingChange() {
+        // given
+        BreakingChange bc1 = mock(BreakingChange.class);
+        given(bc1.getRuleCode()).willReturn("R004");
+        given(bc1.getMessage()).willReturn("parameter X deleted at GET /foo");
+
+        BreakingChange bc2 = mock(BreakingChange.class);
+        given(bc2.getRuleCode()).willReturn("R007");
+        given(bc2.getMessage()).willReturn("response field removed at POST /bar");
+
+        // when
+        underTest.report(Arrays.asList(bc1, bc2), Collections.emptyList(), new Options(), null);
+
+        // then
+        String output = capturedOut.toString(StandardCharsets.UTF_8);
+        assertThat(output).contains("::error title=Breaking Change (R004)::parameter X deleted at GET /foo");
+        assertThat(output).contains("::error title=Breaking Change (R007)::response field removed at POST /bar");
+    }
+
+    @Test
+    void testReportShouldPrintNothingWhenNoBreakingChanges() {
+        // given
+        // when
+        underTest.report(Collections.emptyList(), Collections.emptyList(), new Options(), null);
+
+        // then
+        assertThat(capturedOut.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+
+    @Test
+    void testCanReportShouldReturnTrueForGitHubActionsFormat() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.GITHUB_ACTIONS);
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseForStdOutFormat() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.STDOUT);
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseForJsonFormat() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.JSON);
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseForHtmlFormat() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.HTML);
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
Closes #230

## What changed

- Added `GITHUB_ACTIONS` to the `OutputFormat` enum
- Added `GitHubActionsReporter` that writes `::error title=Breaking Change (RXX)::message` lines to stdout for each breaking change, so GitHub Actions surfaces them as PR annotations on the Files changed tab
- Added `"githubactions"` alias in `OutputFormatsHandler` (maps to `GITHUB_ACTIONS`) so users can pass `--output-formats githubactions` on the CLI; `"github_actions"` also works via the existing `toUpperCase()` + enum name lookup

## Test plan

- [x] `./gradlew check` passes (checkstyle + SpotBugs + tests)
- [x] `GitHubActionsReporterTest` covers: annotation format per breaking change, empty output when no changes, `canReport` true/false for each format
- [x] `OutputFormatsHandlerTest` covers: `"githubactions"` alias resolves to `GITHUB_ACTIONS`, and `"github_actions"` also resolves correctly