### PR TITLE
feat: traverse webhook operations for breaking changes (OpenAPI 3.1)

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/DefaultBreakChecker.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/DefaultBreakChecker.java
@@ -2,7 +2,9 @@ package com.docktape.swagger.brake.core;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import com.docktape.swagger.brake.core.model.Specification;
 import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
@@ -32,9 +34,16 @@ class DefaultBreakChecker implements BreakChecker {
         if (newApi == null) {
             throw new IllegalArgumentException("newApi must be provided");
         }
+        Specification webhookOldSpec = new Specification(oldApi.getWebhooks(), Collections.emptyList(), Collections.emptyList());
+        Specification webhookNewSpec = new Specification(newApi.getWebhooks(), Collections.emptyList(), Collections.emptyList());
         return rules.parallelStream()
-                .map(rule -> rule.checkRule(oldApi, newApi))
-                .flatMap(Collection::stream)
+                .flatMap(rule -> {
+                    Collection<? extends BreakingChange> pathChanges = rule.checkRule(oldApi, newApi);
+                    Collection<? extends BreakingChange> webhookChanges = rule.checkRule(webhookOldSpec, webhookNewSpec);
+                    Collection<BreakingChange> combined = new ArrayList<>(pathChanges);
+                    combined.addAll(webhookChanges);
+                    return combined.stream();
+                })
                 .sorted(Comparator.comparing(bc -> bc.getClass().getSimpleName()))
                 .collect(toList());
     }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Specification.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Specification.java
@@ -1,21 +1,42 @@
 package com.docktape.swagger.brake.core.model;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@RequiredArgsConstructor
 @EqualsAndHashCode
 @ToString
 public class Specification {
     private final Collection<Path> paths;
     private final List<String> serverUrls;
+    private final Collection<Path> webhooks;
+
+    public Specification(Collection<Path> paths, List<String> serverUrls, Collection<Path> webhooks) {
+        this.paths = paths != null ? paths : Collections.emptyList();
+        this.serverUrls = serverUrls != null ? serverUrls : Collections.emptyList();
+        this.webhooks = webhooks != null ? webhooks : Collections.emptyList();
+    }
+
+    public Specification(Collection<Path> paths, List<String> serverUrls) {
+        this(paths, serverUrls, Collections.emptyList());
+    }
+
+    public Specification(Collection<Path> paths) {
+        this(paths, Collections.emptyList(), Collections.emptyList());
+    }
+
+    public Collection<Path> getAllPaths() {
+        Collection<Path> all = new ArrayList<>(paths);
+        all.addAll(webhooks);
+        return all;
+    }
 
     public Optional<Path> getPath(Path path) {
         return getPath(path.getPath(), path.getMethod());

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/OpenApiTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/OpenApiTransformer.java
@@ -1,14 +1,18 @@
 package com.docktape.swagger.brake.core.model.transformer;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.docktape.swagger.brake.core.model.Path;
 import com.docktape.swagger.brake.core.model.Specification;
 import com.docktape.swagger.brake.core.model.store.*;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OpenApiTransformer implements Transformer<OpenAPI, Specification> {
     private final PathTransformer pathTransformer;
+    private final PathItemTransformer pathItemTransformer;
     private final ComponentsTransformer componentsTransformer;
     private final ParametersTransformer parametersTransformer;
     private final ResponsesTransformer responsesTransformer;
@@ -30,16 +35,18 @@ public class OpenApiTransformer implements Transformer<OpenAPI, Specification> {
         ParameterStore parameterStore = parametersTransformer.transform(from.getComponents());
         ResponseStore responseStore = responsesTransformer.transform(from.getComponents());
         Collection<Path> paths;
+        Collection<Path> webhooks;
         try {
             StoreProvider.setSchemaStore(schemaStore);
             StoreProvider.setParameterStore(parameterStore);
             StoreProvider.setResponseStore(responseStore);
             paths = pathTransformer.transform(from.getPaths());
+            webhooks = transformWebhooks(from.getWebhooks());
         } finally {
             StoreProvider.clear();
         }
         List<String> serverUrls = extractServerUrls(from);
-        return new Specification(paths, serverUrls);
+        return new Specification(paths, serverUrls, webhooks);
     }
 
     private List<String> extractServerUrls(OpenAPI from) {
@@ -51,5 +58,23 @@ public class OpenApiTransformer implements Transformer<OpenAPI, Specification> {
             .map(Server::getUrl)
             .filter(url -> url != null)
             .collect(Collectors.toList());
+    }
+
+    private Collection<Path> transformWebhooks(Map<String, PathItem> webhookMap) {
+        if (webhookMap == null || webhookMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return webhookMap.entrySet().stream()
+            .flatMap(e -> pathItemTransformer.transform(e.getValue()).stream()
+                .map(detail -> new Path(
+                    e.getKey(),
+                    detail.getMethod(),
+                    detail.getRequestBody(),
+                    detail.getRequestParameters(),
+                    detail.getResponses(),
+                    detail.isDeprecated(),
+                    detail.isBetaApi()
+                )))
+            .collect(toList());
     }
 }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/webhook/WebhookBreakingChangeIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/webhook/WebhookBreakingChangeIntTest.java
@@ -1,0 +1,57 @@
+package com.docktape.swagger.brake.integration.v3.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.path.PathDeletedBreakingChange;
+import com.docktape.swagger.brake.core.rule.response.ResponseTypeChangedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import com.docktape.swagger.brake.runner.Options;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class WebhookBreakingChangeIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testRemovedWebhookOperationIsDetected() {
+        String oldApiPath = "swaggers/v3/webhook/deleted/api_v1.yaml";
+        String newApiPath = "swaggers/v3/webhook/deleted/api_v2.yaml";
+        PathDeletedBreakingChange expectedChange = new PathDeletedBreakingChange("newPet", HttpMethod.POST);
+        Options options = new Options();
+        options.setOldApiPath(oldApiPath);
+        options.setNewApiPath(newApiPath);
+        options.setStrictValidation(false);
+
+        Collection<BreakingChange> result = execute(options);
+
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).contains(expectedChange)
+        );
+    }
+
+    @Test
+    void testChangedWebhookResponseTypeIsDetected() {
+        String oldApiPath = "swaggers/v3/webhook/response-type-changed/api_v1.yaml";
+        String newApiPath = "swaggers/v3/webhook/response-type-changed/api_v2.yaml";
+        ResponseTypeChangedBreakingChange expectedChange =
+            new ResponseTypeChangedBreakingChange("petUpdated", HttpMethod.POST, "200", "id", "integer", "string");
+        Options options = new Options();
+        options.setOldApiPath(oldApiPath);
+        options.setNewApiPath(newApiPath);
+        options.setStrictValidation(false);
+
+        Collection<BreakingChange> result = execute(options);
+
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).contains(expectedChange)
+        );
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/webhook/deleted/api_v1.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/webhook/deleted/api_v1.yaml
@@ -1,0 +1,30 @@
+openapi: "3.1.0"
+info:
+  title: "Webhook Test API"
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: "List pets"
+      responses:
+        "200":
+          description: "A list of pets"
+webhooks:
+  newPet:
+    post:
+      summary: "New pet created"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+      responses:
+        "200":
+          description: "OK"
+components:
+  schemas: {}

--- a/swagger-brake/src/test/resources/swaggers/v3/webhook/deleted/api_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/webhook/deleted/api_v2.yaml
@@ -1,0 +1,13 @@
+openapi: "3.1.0"
+info:
+  title: "Webhook Test API"
+  version: "2.0.0"
+paths:
+  /pets:
+    get:
+      summary: "List pets"
+      responses:
+        "200":
+          description: "A list of pets"
+components:
+  schemas: {}

--- a/swagger-brake/src/test/resources/swaggers/v3/webhook/response-type-changed/api_v1.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/webhook/response-type-changed/api_v1.yaml
@@ -1,0 +1,29 @@
+openapi: "3.1.0"
+info:
+  title: "Webhook Response Type Change Test API"
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      summary: "List pets"
+      responses:
+        "200":
+          description: "A list of pets"
+webhooks:
+  petUpdated:
+    post:
+      summary: "Pet updated notification"
+      responses:
+        "200":
+          description: "Notification response"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+components:
+  schemas: {}

--- a/swagger-brake/src/test/resources/swaggers/v3/webhook/response-type-changed/api_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/webhook/response-type-changed/api_v2.yaml
@@ -1,0 +1,29 @@
+openapi: "3.1.0"
+info:
+  title: "Webhook Response Type Change Test API"
+  version: "2.0.0"
+paths:
+  /pets:
+    get:
+      summary: "List pets"
+      responses:
+        "200":
+          description: "A list of pets"
+webhooks:
+  petUpdated:
+    post:
+      summary: "Pet updated notification"
+      responses:
+        "200":
+          description: "Notification response"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+components:
+  schemas: {}


### PR DESCRIPTION
Closes #205

## What changed

Webhooks defined in OpenAPI 3.1 specs are now checked for breaking changes by running them through the existing rule engine:

- **`Specification`**: Added a `webhooks` field (`Collection<Path>`) separate from `paths`. Added `getAllPaths()` returning the combined set. The existing `getPath()` lookup continues to search only `paths` so there is no cross-contamination between the two runs.
- **`OpenApiTransformer`**: Reads `from.getWebhooks()` (`Map<String, PathItem>`) and uses the existing `PathItemTransformer` to produce `Path` objects, using the webhook name as the path string.
- **`DefaultBreakChecker`**: Runs all rules twice per check - once for regular paths (as before) and once for webhook paths (passed as the `paths` argument of a temporary `Specification`). Results are merged before sorting.

No existing rules were modified; any rule that iterates `oldApi.getPaths()` automatically covers webhooks in the webhook-specific run.

## Test plan

- [x] `./gradlew check` passes (all modules)
- [x] New integration test: removing a webhook operation is flagged as `PathDeletedBreakingChange`
- [x] New integration test: changing a webhook response schema type is flagged as `ResponseTypeChangedBreakingChange`