### PR TITLE
feat(R026): detect parameter default value changes

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameter.java
@@ -22,9 +22,14 @@ public class RequestParameter {
     private final boolean required;
     private final Schema schema;
     private final AttributeType requestParameterType;
+    private final String defaultValue;
 
     public RequestParameter(RequestParameterInType inType, String name, boolean required, AttributeType requestParameterType) {
-        this(inType, name, required, null, requestParameterType);
+        this(inType, name, required, null, requestParameterType, null);
+    }
+
+    public RequestParameter(RequestParameterInType inType, String name, boolean required, Schema schema, AttributeType requestParameterType) {
+        this(inType, name, required, schema, requestParameterType, null);
     }
 
     public Optional<Schema> getSchema() {

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameterFactory.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameterFactory.java
@@ -33,6 +33,7 @@ public class RequestParameterFactory {
         String name = from.getName();
         boolean required = BooleanUtils.toBoolean(from.getRequired());
         Schema swSchema = from.getSchema();
+        String defaultValue = swSchema != null && swSchema.getDefault() != null ? swSchema.getDefault().toString() : null;
         if (swSchema != null) {
             // Use TypeResolver to handle both OpenAPI 3.0.x single types and 3.1.x type arrays
             String type = typeResolver.resolveType(swSchema);
@@ -50,6 +51,7 @@ public class RequestParameterFactory {
                     .required(required)
                     .requestParameterType(requestParameterType)
                     .schema(transformedSchema)
+                    .defaultValue(defaultValue)
                     .maximum(maximum)
                     .exclusiveMaximum(BooleanUtils.toBoolean(exclusiveMaximum))
                     .minimum(minimum)
@@ -64,6 +66,7 @@ public class RequestParameterFactory {
                     .required(required)
                     .requestParameterType(requestParameterType)
                     .schema(transformedSchema)
+                    .defaultValue(defaultValue)
                     .maxLength(maxLength)
                     .minLength(minLength)
                     .build();
@@ -77,6 +80,7 @@ public class RequestParameterFactory {
                     .required(required)
                     .requestParameterType(requestParameterType)
                     .schema(transformedSchema)
+                    .defaultValue(defaultValue)
                     .maxItems(maxItems)
                     .minItems(minItems)
                     .uniqueItems(uniqueItems)
@@ -89,6 +93,7 @@ public class RequestParameterFactory {
                     .required(required)
                     .requestParameterType(GENERIC)
                     .schema(transformedSchema)
+                    .defaultValue(defaultValue)
                     .build();
             }
         }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestParameterDefaultChangedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestParameterDefaultChangedBreakingChange.java
@@ -1,0 +1,32 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestParameterDefaultChangedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String parameterName;
+    private final String oldDefault;
+    private final String newDefault;
+
+    @Override
+    public String getMessage() {
+        return format("Default value of %s changed from '%s' to '%s' at %s %s", parameterName, oldDefault, newDefault, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R026";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestParameterDefaultChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestParameterDefaultChangedRule.java
@@ -1,0 +1,54 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.model.parameter.RequestParameter;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestParameterDefaultChangedRule implements BreakingChangeRule<RequestParameterDefaultChangedBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestParameterDefaultChangedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestParameterDefaultChangedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                if (CollectionUtils.isNotEmpty(path.getRequestParameters())) {
+                    for (RequestParameter requestParameter : path.getRequestParameters()) {
+                        Optional<RequestParameter> newRequestParameter = newPath.getRequestParameterByName(requestParameter.getName());
+                        if (newRequestParameter.isPresent()) {
+                            String oldDefault = requestParameter.getDefaultValue();
+                            String newDefault = newRequestParameter.get().getDefaultValue();
+                            if (!Objects.equals(oldDefault, newDefault)) {
+                                breakingChanges.add(
+                                    new RequestParameterDefaultChangedBreakingChange(
+                                        path.getPath(), path.getMethod(), requestParameter.getName(), oldDefault, newDefault));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/request/RequestParameterDefaultChangedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/request/RequestParameterDefaultChangedIntTest.java
@@ -1,0 +1,81 @@
+package com.docktape.swagger.brake.integration.v2.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestParameterDefaultChangedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RequestParameterDefaultChangedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testDefaultAddedIsDetected() {
+        // given
+        String oldApiPath = "swaggers/v2/request/parameterdefaultchanged/defaultadded/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/parameterdefaultchanged/defaultadded/petstore_v2.yaml";
+        RequestParameterDefaultChangedBreakingChange bc =
+            new RequestParameterDefaultChangedBreakingChange("/pet/findByStatus", HttpMethod.GET, "status", null, "available");
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+
+    @Test
+    void testDefaultChangedIsDetected() {
+        // given
+        String oldApiPath = "swaggers/v2/request/parameterdefaultchanged/defaultchanged/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/parameterdefaultchanged/defaultchanged/petstore_v2.yaml";
+        RequestParameterDefaultChangedBreakingChange bc =
+            new RequestParameterDefaultChangedBreakingChange("/pet/findByStatus", HttpMethod.GET, "status", "available", "pending");
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+
+    @Test
+    void testDefaultRemovedIsDetected() {
+        // given
+        String oldApiPath = "swaggers/v2/request/parameterdefaultchanged/defaultremoved/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/parameterdefaultchanged/defaultremoved/petstore_v2.yaml";
+        RequestParameterDefaultChangedBreakingChange bc =
+            new RequestParameterDefaultChangedBreakingChange("/pet/findByStatus", HttpMethod.GET, "status", "available", null);
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+
+    @Test
+    void testNoDefaultOnEitherSideIsNotDetected() {
+        // given
+        String oldApiPath = "swaggers/v2/request/parameterdefaultchanged/nodefault/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/parameterdefaultchanged/nodefault/petstore_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultadded/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultadded/petstore.yaml
@@ -1,0 +1,24 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultadded/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultadded/petstore_v2.yaml
@@ -1,0 +1,25 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+        default: "available"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultchanged/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultchanged/petstore.yaml
@@ -1,0 +1,25 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+        default: "available"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultchanged/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultchanged/petstore_v2.yaml
@@ -1,0 +1,25 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+        default: "pending"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultremoved/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultremoved/petstore.yaml
@@ -1,0 +1,25 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+        default: "available"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultremoved/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/defaultremoved/petstore_v2.yaml
@@ -1,0 +1,24 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/nodefault/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/nodefault/petstore.yaml
@@ -1,0 +1,24 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/nodefault/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/parameterdefaultchanged/nodefault/petstore_v2.yaml
@@ -1,0 +1,24 @@
+---
+swagger: "2.0"
+info:
+  description: "Swagger Petstore"
+  version: "1.0.0"
+  title: "Swagger Petstore"
+host: "petstore.swagger.io"
+basePath: "/v2"
+schemes:
+- "https"
+paths:
+  /pet/findByStatus:
+    get:
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"


### PR DESCRIPTION
Closes #217

## What changed

- Added `defaultValue` field (nullable `String`) to `RequestParameter` and populated it from `schema.getDefault()` in `RequestParameterFactory`
- New `RequestParameterDefaultChangedBreakingChange` (rule code R026) reports when a parameter's default value is added, changed, or removed
- New `RequestParameterDefaultChangedRule` Spring component wires into the existing rule collection; compares `defaultValue` between old and new parameter using `Objects.equals` to handle null cleanly

## Test plan

- [x] `./gradlew check` passes (checkstyle + spotbugs + all tests)
- [x] `testDefaultAddedIsDetected` - null to "available" flagged
- [x] `testDefaultChangedIsDetected` - "available" to "pending" flagged
- [x] `testDefaultRemovedIsDetected` - "available" to null flagged
- [x] `testNoDefaultOnEitherSideIsNotDetected` - null/null not flagged