### PR TITLE
feat(R017): detect multipleOf constraint changes for numeric schemas

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 public class NumberSchema extends Schema {
     private final BigDecimal maximum;
     private final BigDecimal minimum;
+    private final BigDecimal multipleOf;
     
     /**
      * Deprecated: Use {@link #exclusiveMaximumValue} instead.
@@ -67,6 +68,7 @@ public class NumberSchema extends Schema {
         // Convert boolean to numeric representation for backward compatibility
         this.exclusiveMaximumValue = exclusiveMaximum && maximum != null ? maximum : null;
         this.exclusiveMinimumValue = exclusiveMinimum && minimum != null ? minimum : null;
+        this.multipleOf = null;
     }
 
     /**
@@ -82,6 +84,24 @@ public class NumberSchema extends Schema {
      */
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, BigDecimal exclusiveMaximumValue, BigDecimal exclusiveMinimumValue) {
+        this(type, enumValues, schemaAttributes, schema, maximum, minimum, exclusiveMaximumValue, exclusiveMinimumValue, null);
+    }
+
+    /**
+     * Constructs a number schema with numeric exclusive bounds and a multipleOf constraint.
+     * @param type the type
+     * @param enumValues the enum values
+     * @param schemaAttributes the attributes
+     * @param schema the underlying schema
+     * @param maximum the maximum constraint
+     * @param minimum the minimum constraint
+     * @param exclusiveMaximumValue the exclusive maximum value (can be different from maximum)
+     * @param exclusiveMinimumValue the exclusive minimum value (can be different from minimum)
+     * @param multipleOf the multipleOf constraint
+     */
+    public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
+                        BigDecimal maximum, BigDecimal minimum, BigDecimal exclusiveMaximumValue, BigDecimal exclusiveMinimumValue,
+                        BigDecimal multipleOf) {
         super(type, enumValues, schemaAttributes, schema, null);
         this.maximum = maximum;
         this.minimum = minimum;
@@ -90,5 +110,6 @@ public class NumberSchema extends Schema {
         // Set boolean flags based on numeric values for backward compatibility
         this.exclusiveMaximum = exclusiveMaximumValue != null;
         this.exclusiveMinimum = exclusiveMinimumValue != null;
+        this.multipleOf = multipleOf;
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
@@ -41,6 +41,7 @@ public class SchemaBuilder {
     private BigDecimal exclusiveMaximumValue;
     private BigDecimal exclusiveMinimumValue;
     private Set<String> extensibleEnum;
+    private BigDecimal multipleOf;
 
     public SchemaBuilder(String type) {
         this.type = type;
@@ -160,6 +161,16 @@ public class SchemaBuilder {
     }
 
     /**
+     * Sets the multipleOf constraint.
+     * @param multipleOf the multipleOf value
+     * @return this builder
+     */
+    public SchemaBuilder multipleOf(BigDecimal multipleOf) {
+        this.multipleOf = multipleOf;
+        return this;
+    }
+
+    /**
      * Builds a {@link Schema} instance.
      * @return the constructed {@link Schema} instance.
      */
@@ -194,7 +205,7 @@ public class SchemaBuilder {
             BigDecimal effectiveExclusiveMin = exclusiveMinimumValue != null ? exclusiveMinimumValue
                 : (exclusiveMinimum && minimum != null ? minimum : null);
             return new NumberSchema(type, enumValues, schemaAttributes, schema, maximum, minimum,
-                effectiveExclusiveMax, effectiveExclusiveMin);
+                effectiveExclusiveMax, effectiveExclusiveMin, multipleOf);
         } else if (AttributeType.getArrayTypes().contains(attributeType)) {
             return new ArraySchema(type, enumValues, schemaAttributes, schema, maxItems, minItems, uniqueItems);
         } else {

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/NumberRequestParameter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/NumberRequestParameter.java
@@ -19,6 +19,7 @@ public class NumberRequestParameter extends RequestParameter {
     private BigDecimal minimum;
     private boolean exclusiveMaximum;
     private boolean exclusiveMinimum;
+    private BigDecimal multipleOf;
 
     /**
      * Constructor to create an instance.
@@ -31,16 +32,19 @@ public class NumberRequestParameter extends RequestParameter {
      * @param minimum the minimum
      * @param exclusiveMaximum whether its exclusively maximized
      * @param exclusiveMinimum whether its exclusively minimized
+     * @param multipleOf the multipleOf constraint
      */
     public NumberRequestParameter(RequestParameterInType inType, String name,
                                   boolean required, Schema schema, AttributeType requestParameterType,
                                   BigDecimal maximum, BigDecimal minimum,
-                                  boolean exclusiveMaximum, boolean exclusiveMinimum) {
+                                  boolean exclusiveMaximum, boolean exclusiveMinimum,
+                                  BigDecimal multipleOf) {
         super(inType, name, required, schema, requestParameterType);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximum = exclusiveMaximum;
         this.exclusiveMinimum = exclusiveMinimum;
+        this.multipleOf = multipleOf;
     }
 
     /**

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameterFactory.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameterFactory.java
@@ -45,6 +45,7 @@ public class RequestParameterFactory {
                 Boolean exclusiveMaximum = swSchema.getExclusiveMaximum();
                 BigDecimal minimum = swSchema.getMinimum();
                 Boolean exclusiveMinimum = swSchema.getExclusiveMinimum();
+                BigDecimal multipleOf = swSchema.getMultipleOf();
                 return NumberRequestParameter.builder()
                     .inType(inType)
                     .name(name)
@@ -56,6 +57,7 @@ public class RequestParameterFactory {
                     .exclusiveMaximum(BooleanUtils.toBoolean(exclusiveMaximum))
                     .minimum(minimum)
                     .exclusiveMinimum(BooleanUtils.toBoolean(exclusiveMinimum))
+                    .multipleOf(multipleOf)
                     .build();
             } else if (AttributeType.getStringTypes().contains(requestParameterType)) {
                 Integer maxLength = swSchema.getMaxLength();

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -118,6 +118,7 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
         schemaBuilder.uniqueItems(swSchema.getUniqueItems());
         schemaBuilder.maximum(swSchema.getMaximum());
         schemaBuilder.minimum(swSchema.getMinimum());
+        schemaBuilder.multipleOf(swSchema.getMultipleOf());
         
         // Handle exclusive bounds based on OpenAPI version
         // In OpenAPI 3.0.x: exclusiveMaximum/exclusiveMinimum are Boolean modifiers, stored via getExclusiveMaximum()/getExclusiveMinimum()

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/NumberConstrainedValue.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/NumberConstrainedValue.java
@@ -16,4 +16,5 @@ public class NumberConstrainedValue implements ConstrainedValue {
     private final BigDecimal minimum;
     private final boolean exclusiveMaximum;
     private final boolean exclusiveMinimum;
+    private final BigDecimal multipleOf;
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/RequestParameterConstraintChangeRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/RequestParameterConstraintChangeRule.java
@@ -72,7 +72,7 @@ public class RequestParameterConstraintChangeRule implements BreakingChangeRule<
             return new ArrayConstrainedValue(arSchema.getMaxItems(), arSchema.getMinItems(), arSchema.getUniqueItems());
         } else if (schema instanceof NumberSchema) {
             NumberSchema nuSchema = (NumberSchema) schema;
-            return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum());
+            return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum(), nuSchema.getMultipleOf());
         } else if (schema instanceof StringSchema) {
             StringSchema stSchema = (StringSchema) schema;
             return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength());
@@ -87,7 +87,8 @@ public class RequestParameterConstraintChangeRule implements BreakingChangeRule<
             return new ArrayConstrainedValue(arParameter.getMaxItems(), arParameter.getMinItems(), arParameter.getUniqueItems());
         } else if (parameter instanceof NumberRequestParameter) {
             NumberRequestParameter nuParameter = (NumberRequestParameter) parameter;
-            return new NumberConstrainedValue(nuParameter.getMaximum(), nuParameter.getMinimum(), nuParameter.isExclusiveMaximum(), nuParameter.isExclusiveMinimum());
+            return new NumberConstrainedValue(nuParameter.getMaximum(), nuParameter.getMinimum(),
+                nuParameter.isExclusiveMaximum(), nuParameter.isExclusiveMinimum(), nuParameter.getMultipleOf());
         } else if (parameter instanceof StringRequestParameter) {
             StringRequestParameter stParameter = (StringRequestParameter) parameter;
             return new StringConstrainedValue(stParameter.getMaxLength(), stParameter.getMinLength());

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMultipleOfConstraint.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMultipleOfConstraint.java
@@ -1,0 +1,40 @@
+package com.docktape.swagger.brake.core.rule.request.parameter.constraint.number;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.Constraint;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ConstraintChange;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.NumberConstrainedValue;
+import org.springframework.stereotype.Component;
+
+@Component
+class NumberMultipleOfConstraint implements Constraint<NumberConstrainedValue> {
+    public static final String MULTIPLE_OF_ATTRIBUTE_NAME = "multipleOf";
+
+    @Override
+    public Optional<ConstraintChange> validateConstraints(NumberConstrainedValue oldRequestParameter, NumberConstrainedValue newRequestParameter) {
+        ConstraintChange result = null;
+        if (oldRequestParameter != null && newRequestParameter != null) {
+            BigDecimal oldMultipleOf = oldRequestParameter.getMultipleOf();
+            BigDecimal newMultipleOf = newRequestParameter.getMultipleOf();
+            if (oldMultipleOf == null && newMultipleOf != null) {
+                result = new ConstraintChange(MULTIPLE_OF_ATTRIBUTE_NAME,
+                    null,
+                    new PrettyFormattedBigDecimal(newMultipleOf)
+                );
+            } else if (oldMultipleOf != null && newMultipleOf != null && oldMultipleOf.compareTo(newMultipleOf) != 0) {
+                result = new ConstraintChange(MULTIPLE_OF_ATTRIBUTE_NAME,
+                    new PrettyFormattedBigDecimal(oldMultipleOf),
+                    new PrettyFormattedBigDecimal(newMultipleOf)
+                );
+            }
+        }
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Class<NumberConstrainedValue> handledRequestParameter() {
+        return NumberConstrainedValue.class;
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedRule.java
@@ -80,7 +80,7 @@ public class ResponseConstraintChangedRule implements BreakingChangeRule<Respons
             return new ArrayConstrainedValue(arSchema.getMaxItems(), arSchema.getMinItems(), arSchema.getUniqueItems());
         } else if (schema instanceof NumberSchema) {
             NumberSchema nuSchema = (NumberSchema) schema;
-            return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum());
+            return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum(), nuSchema.getMultipleOf());
         } else if (schema instanceof StringSchema) {
             StringSchema stSchema = (StringSchema) schema;
             return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength());

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMaximumConstraintTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMaximumConstraintTest.java
@@ -20,7 +20,8 @@ class NumberMaximumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -35,7 +36,8 @@ class NumberMaximumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = null;
         // when
@@ -51,13 +53,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -72,13 +76,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -93,13 +99,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "exclusiveMaximum", false, true
@@ -117,13 +125,16 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN.add(BigDecimal.ONE),
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
+
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -138,14 +149,17 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN.add(BigDecimal.ONE),
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
+
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
         // then
@@ -159,13 +173,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maximum", BigDecimal.TEN, BigDecimal.ONE
@@ -183,13 +199,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maximum", BigDecimal.TEN, BigDecimal.ONE
@@ -207,13 +225,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maximum", BigDecimal.TEN, BigDecimal.ONE
@@ -231,13 +251,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maximum", BigDecimal.TEN, BigDecimal.ONE
@@ -255,14 +277,18 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN.add(new BigDecimal("0.5")),
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
+
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE.add(new BigDecimal("0.5")),
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
+
         ConstraintChange expected = new ConstraintChange(
             "maximum", BigDecimal.TEN.add(new BigDecimal("0.5")), BigDecimal.ONE.add(new BigDecimal("0.5"))
         );
@@ -279,14 +305,18 @@ class NumberMaximumConstraintTest {
             BigDecimal.TEN.add(new BigDecimal("0.5")),
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
+
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE.add(new BigDecimal("0.5")),
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
+
         ConstraintChange expected = new ConstraintChange(
             "maximum", BigDecimal.TEN.add(new BigDecimal("0.5")), BigDecimal.ONE.add(new BigDecimal("0.5"))
         );
@@ -303,13 +333,15 @@ class NumberMaximumConstraintTest {
             null,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maximum", null, BigDecimal.ONE
@@ -327,13 +359,15 @@ class NumberMaximumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             null,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMinimumConstraintTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMinimumConstraintTest.java
@@ -20,7 +20,8 @@ class NumberMinimumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -35,7 +36,8 @@ class NumberMinimumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = null;
         // when
@@ -51,13 +53,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ZERO,
             true,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -72,13 +76,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.TEN,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.ONE,
             true,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -93,13 +99,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.TEN,
             true,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.TEN,
             false,
-            false
+            false,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -114,13 +122,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.TEN,
             false,
-            false
+            false,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.TEN,
             true,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "exclusiveMinimum", false, true
@@ -138,13 +148,16 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.TEN.subtract(BigDecimal.ONE),
             true,
-            true
+            true,
+            null
         );
+
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.TEN,
             false,
-            false
+            false,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -159,14 +172,17 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.TEN,
             false,
-            false
+            false,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.TEN,
             BigDecimal.TEN.subtract(BigDecimal.ONE),
             true,
-            true
+            true,
+            null
         );
+
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
         // then
@@ -180,13 +196,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ONE,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.TEN,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "minimum", BigDecimal.ONE, BigDecimal.TEN
@@ -204,13 +222,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ONE,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.TEN,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "minimum", BigDecimal.ONE, BigDecimal.TEN
@@ -228,13 +248,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ONE,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.TEN,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "minimum", BigDecimal.ONE, BigDecimal.TEN
@@ -252,13 +274,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ONE,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.TEN,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "minimum", BigDecimal.ONE, BigDecimal.TEN
@@ -276,14 +300,18 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ONE.subtract(new BigDecimal("0.5")),
             false,
-            true
+            true,
+            null
         );
+
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.TEN.subtract(new BigDecimal("0.5")),
             false,
-            true
+            true,
+            null
         );
+
         ConstraintChange expected = new ConstraintChange(
             "minimum", BigDecimal.ONE.subtract(new BigDecimal("0.5")), BigDecimal.TEN.subtract(new BigDecimal("0.5"))
         );
@@ -300,14 +328,18 @@ class NumberMinimumConstraintTest {
             BigDecimal.TEN,
             BigDecimal.ONE.subtract(new BigDecimal("0.5")),
             false,
-            true
+            true,
+            null
         );
+
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.TEN.subtract(new BigDecimal("0.5")),
             false,
-            true
+            true,
+            null
         );
+
         ConstraintChange expected = new ConstraintChange(
             "minimum", BigDecimal.ONE.subtract(new BigDecimal("0.5")), BigDecimal.TEN.subtract(new BigDecimal("0.5"))
         );
@@ -324,13 +356,15 @@ class NumberMinimumConstraintTest {
             null,
             null,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             BigDecimal.ONE,
             BigDecimal.ONE,
             false,
-            true
+            true,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "minimum", null, BigDecimal.ONE
@@ -348,13 +382,15 @@ class NumberMinimumConstraintTest {
             BigDecimal.ONE,
             BigDecimal.ZERO,
             false,
-            true
+            true,
+            null
         );
         NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
             null,
             null,
             false,
-            true
+            true,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMultipleOfConstraintTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/number/NumberMultipleOfConstraintTest.java
@@ -1,0 +1,120 @@
+package com.docktape.swagger.brake.core.rule.request.parameter.constraint.number;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ConstraintChange;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.NumberConstrainedValue;
+import org.junit.jupiter.api.Test;
+
+class NumberMultipleOfConstraintTest {
+    private NumberMultipleOfConstraint underTest = new NumberMultipleOfConstraint();
+
+    @Test
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenNullOldRequestParamIsGiven() {
+        // given
+        NumberConstrainedValue oldRequestParameter = null;
+        NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenNullNewRequestParamIsGiven() {
+        // given
+        NumberConstrainedValue oldRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        NumberConstrainedValue newRequestParameter = null;
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenBothMultipleOfAreNull() {
+        // given
+        NumberConstrainedValue oldRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, null
+        );
+        NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, null
+        );
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testValidateConstraintsShouldReportBreakingChangeWhenMultipleOfIsIntroduced() {
+        // given
+        NumberConstrainedValue oldRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, null
+        );
+        NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        ConstraintChange expected = new ConstraintChange("multipleOf", null, new BigDecimal("5"));
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getAttribute()).isEqualTo(expected.getAttribute());
+        assertThat(result.get().getOldValue()).isEqualTo(expected.getOldValue());
+    }
+
+    @Test
+    void testValidateConstraintsShouldReportBreakingChangeWhenMultipleOfChanges() {
+        // given
+        NumberConstrainedValue oldRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("3")
+        );
+        ConstraintChange expected = new ConstraintChange("multipleOf", new BigDecimal("5"), new BigDecimal("3"));
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getAttribute()).isEqualTo(expected.getAttribute());
+    }
+
+    @Test
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenMultipleOfIsRemoved() {
+        // given - removing multipleOf is a loosening, not a breaking change
+        NumberConstrainedValue oldRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, null
+        );
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenMultipleOfIsUnchanged() {
+        // given
+        NumberConstrainedValue oldRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        NumberConstrainedValue newRequestParameter = new NumberConstrainedValue(
+            null, null, false, false, new BigDecimal("5")
+        );
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isNotPresent();
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
@@ -50,8 +50,8 @@ class ResponseMediaTypeGeneralizedRuleTest {
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
 
-        Specification oldApi = new Specification(List.of(oldPath));
-        Specification newApi = new Specification(List.of(newPath));
+        Specification oldApi = new Specification(List.of(oldPath), List.of());
+        Specification newApi = new Specification(List.of(newPath), List.of());
 
         // when
         Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
@@ -77,8 +77,8 @@ class ResponseMediaTypeGeneralizedRuleTest {
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
 
-        Specification oldApi = new Specification(List.of(oldPath));
-        Specification newApi = new Specification(List.of(newPath));
+        Specification oldApi = new Specification(List.of(oldPath), List.of());
+        Specification newApi = new Specification(List.of(newPath), List.of());
 
         // when
         Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
@@ -106,8 +106,8 @@ class ResponseMediaTypeGeneralizedRuleTest {
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
 
-        Specification oldApi = new Specification(List.of(oldPath));
-        Specification newApi = new Specification(List.of(newPath));
+        Specification oldApi = new Specification(List.of(oldPath), List.of());
+        Specification newApi = new Specification(List.of(newPath), List.of());
 
         // when
         Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);
@@ -134,8 +134,8 @@ class ResponseMediaTypeGeneralizedRuleTest {
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
 
-        Specification oldApi = new Specification(List.of(oldPath));
-        Specification newApi = new Specification(List.of(newPath));
+        Specification oldApi = new Specification(List.of(oldPath), List.of());
+        Specification newApi = new Specification(List.of(newPath), List.of());
 
         // when
         Collection<ResponseMediaTypeGeneralizedBreakingChange> result = underTest.checkRule(oldApi, newApi);


### PR DESCRIPTION
Closes #209

## What changed

Added `multipleOf` constraint detection for numeric request parameters and body schema attributes. When a `multipleOf` constraint is introduced or changed on a numeric field, it is now reported as a breaking change (rule R017 - constraint change). Removing `multipleOf` is not flagged because it loosens the constraint.

### Files changed

- **`NumberSchema`** - added `multipleOf: BigDecimal` field and a full constructor accepting it
- **`SchemaBuilder`** - added `multipleOf()` builder method, passed to `NumberSchema.build()`
- **`SchemaTransformer`** - populates `multipleOf` from `swSchema.getMultipleOf()`
- **`NumberRequestParameter`** - added `multipleOf: BigDecimal` field
- **`RequestParameterFactory`** - reads `swSchema.getMultipleOf()` and passes it to the builder
- **`NumberConstrainedValue`** - added `multipleOf: BigDecimal` field (5th arg)
- **`RequestParameterConstraintChangeRule`** - passes `multipleOf` when constructing `NumberConstrainedValue` for both schema and parameter paths
- **`NumberMultipleOfConstraint`** (new) - `@Component` implementing `Constraint<NumberConstrainedValue>` that detects introduce/change as breaking, removal as non-breaking

## Test plan

- [x] `./gradlew :swagger-brake:check :swagger-brake-cli:check` passes (checkstyle, SpotBugs, tests)
- [x] `NumberMultipleOfConstraintTest` - 7 tests: null old/new params, both null, introduce (breaking), change (breaking), remove (not breaking), unchanged (not breaking)
- [x] Existing `NumberMaximumConstraintTest` and `NumberMinimumConstraintTest` updated to compile with the new 5-arg `NumberConstrainedValue` constructor