### PR TITLE
feat(R017): detect pattern (regex) constraint changes for string params

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
@@ -18,6 +18,7 @@ public class SchemaBuilder {
     private Schema schema;
     private Integer maxLength;
     private Integer minLength;
+    private String pattern;
     private Integer maxItems;
     private Integer minItems;
     private Boolean uniqueItems;
@@ -75,6 +76,11 @@ public class SchemaBuilder {
 
     public SchemaBuilder minLength(Integer minLength) {
         this.minLength = minLength;
+        return this;
+    }
+
+    public SchemaBuilder pattern(String pattern) {
+        this.pattern = pattern;
         return this;
     }
 
@@ -208,7 +214,7 @@ public class SchemaBuilder {
             schemaAttributes = new TreeSet<>(attributes);
         }
         if (AttributeType.getStringTypes().contains(attributeType)) {
-            return new StringSchema(type, enumValues, schemaAttributes, schema, maxLength, minLength, extensibleEnum, constValue);
+            return new StringSchema(type, enumValues, schemaAttributes, schema, maxLength, minLength, extensibleEnum, constValue, pattern);
         } else if (AttributeType.getNumberTypes().contains(attributeType)) {
             // Use numeric exclusive bounds if available, otherwise convert from boolean flags
             BigDecimal effectiveExclusiveMax = exclusiveMaximumValue != null ? exclusiveMaximumValue

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/StringSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/StringSchema.java
@@ -12,6 +12,7 @@ import lombok.ToString;
 public class StringSchema extends Schema {
     private final Integer maxLength;
     private final Integer minLength;
+    private final String pattern;
 
     /**
      * Constructs a string schema.
@@ -23,11 +24,13 @@ public class StringSchema extends Schema {
      * @param minLength the minLength constraint
      * @param extEnum the x-extensible-enum values
      * @param constValue the const value (nullable)
+     * @param pattern the pattern constraint
      */
     public StringSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
-                        Integer maxLength, Integer minLength, Set<String> extEnum, String constValue) {
+                        Integer maxLength, Integer minLength, Set<String> extEnum, String constValue, String pattern) {
         super(type, enumValues, schemaAttributes, schema, extEnum, constValue);
         this.maxLength = maxLength;
         this.minLength = minLength;
+        this.pattern = pattern;
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameterFactory.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/RequestParameterFactory.java
@@ -62,6 +62,7 @@ public class RequestParameterFactory {
             } else if (AttributeType.getStringTypes().contains(requestParameterType)) {
                 Integer maxLength = swSchema.getMaxLength();
                 Integer minLength = swSchema.getMinLength();
+                String pattern = swSchema.getPattern();
                 return StringRequestParameter.builder()
                     .inType(inType)
                     .name(name)
@@ -71,6 +72,7 @@ public class RequestParameterFactory {
                     .defaultValue(defaultValue)
                     .maxLength(maxLength)
                     .minLength(minLength)
+                    .pattern(pattern)
                     .build();
             } else if (AttributeType.getArrayTypes().contains(requestParameterType)) {
                 Integer maxItems = swSchema.getMaxItems();

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/StringRequestParameter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/parameter/StringRequestParameter.java
@@ -15,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 public class StringRequestParameter extends RequestParameter {
     private Integer maxLength;
     private Integer minLength;
+    private String pattern;
 
     /**
      * Constructor to create an instance.
@@ -25,12 +26,14 @@ public class StringRequestParameter extends RequestParameter {
      * @param requestParameterType the {@link AttributeType}
      * @param maxLength the maximum length
      * @param minLength the minimum length
+     * @param pattern the pattern constraint
      */
     public StringRequestParameter(RequestParameterInType inType, String name,
                                   boolean required, Schema schema, AttributeType requestParameterType,
-                                  Integer maxLength, Integer minLength) {
+                                  Integer maxLength, Integer minLength, String pattern) {
         super(inType, name, required, schema, requestParameterType);
         this.maxLength = maxLength;
         this.minLength = minLength;
+        this.pattern = pattern;
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -113,6 +113,7 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
         SchemaBuilder schemaBuilder = new SchemaBuilder(schemaType);
         schemaBuilder.maxLength(swSchema.getMaxLength());
         schemaBuilder.minLength(swSchema.getMinLength());
+        schemaBuilder.pattern(swSchema.getPattern());
         schemaBuilder.maxItems(swSchema.getMaxItems());
         schemaBuilder.minItems(swSchema.getMinItems());
         schemaBuilder.uniqueItems(swSchema.getUniqueItems());

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/RequestParameterConstraintChangeRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/RequestParameterConstraintChangeRule.java
@@ -75,7 +75,7 @@ public class RequestParameterConstraintChangeRule implements BreakingChangeRule<
             return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum(), nuSchema.getMultipleOf());
         } else if (schema instanceof StringSchema) {
             StringSchema stSchema = (StringSchema) schema;
-            return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength());
+            return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength(), stSchema.getPattern());
         } else {
             return new NoConstrainedValue();
         }
@@ -91,7 +91,7 @@ public class RequestParameterConstraintChangeRule implements BreakingChangeRule<
                 nuParameter.isExclusiveMaximum(), nuParameter.isExclusiveMinimum(), nuParameter.getMultipleOf());
         } else if (parameter instanceof StringRequestParameter) {
             StringRequestParameter stParameter = (StringRequestParameter) parameter;
-            return new StringConstrainedValue(stParameter.getMaxLength(), stParameter.getMinLength());
+            return new StringConstrainedValue(stParameter.getMaxLength(), stParameter.getMinLength(), stParameter.getPattern());
         } else {
             return new NoConstrainedValue();
         }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/StringConstrainedValue.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/StringConstrainedValue.java
@@ -12,4 +12,5 @@ import lombok.ToString;
 public class StringConstrainedValue implements ConstrainedValue {
     private final Integer maxLength;
     private final Integer minLength;
+    private final String pattern;
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/string/StringPatternConstraint.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/string/StringPatternConstraint.java
@@ -1,0 +1,37 @@
+package com.docktape.swagger.brake.core.rule.request.parameter.constraint.string;
+
+import java.util.Optional;
+
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.Constraint;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.ConstraintChange;
+import com.docktape.swagger.brake.core.rule.request.parameter.constraint.StringConstrainedValue;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringPatternConstraint implements Constraint<StringConstrainedValue> {
+    public static final String PATTERN_ATTRIBUTE_NAME = "pattern";
+
+    @Override
+    public Optional<ConstraintChange> validateConstraints(StringConstrainedValue oldConstrainedValue, StringConstrainedValue newConstrainedValue) {
+        ConstraintChange result = null;
+        if (oldConstrainedValue != null && newConstrainedValue != null) {
+            String oldPattern = oldConstrainedValue.getPattern();
+            String newPattern = newConstrainedValue.getPattern();
+            if (oldPattern == null && newPattern != null) {
+                result = new ConstraintChange(
+                    PATTERN_ATTRIBUTE_NAME, null, newPattern
+                );
+            } else if (oldPattern != null && newPattern != null && !oldPattern.equals(newPattern)) {
+                result = new ConstraintChange(
+                    PATTERN_ATTRIBUTE_NAME, oldPattern, newPattern
+                );
+            }
+        }
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Class<StringConstrainedValue> handledRequestParameter() {
+        return StringConstrainedValue.class;
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseConstraintChangedRule.java
@@ -83,7 +83,7 @@ public class ResponseConstraintChangedRule implements BreakingChangeRule<Respons
             return new NumberConstrainedValue(nuSchema.getMaximum(), nuSchema.getMinimum(), nuSchema.isExclusiveMaximum(), nuSchema.isExclusiveMinimum(), nuSchema.getMultipleOf());
         } else if (schema instanceof StringSchema) {
             StringSchema stSchema = (StringSchema) schema;
-            return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength());
+            return new StringConstrainedValue(stSchema.getMaxLength(), stSchema.getMinLength(), stSchema.getPattern());
         } else {
             return new NoConstrainedValue();
         }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/string/StringMaxLengthConstraintTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/string/StringMaxLengthConstraintTest.java
@@ -17,7 +17,8 @@ class StringMaxLengthConstraintTest {
         StringConstrainedValue oldRequestParameter = null;
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -30,7 +31,8 @@ class StringMaxLengthConstraintTest {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         StringConstrainedValue newRequestParameter = null;
         // when
@@ -44,11 +46,13 @@ class StringMaxLengthConstraintTest {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -61,11 +65,13 @@ class StringMaxLengthConstraintTest {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
             2,
-            1
+            1,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -78,11 +84,13 @@ class StringMaxLengthConstraintTest {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
             null,
-            1
+            1,
+            null
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -95,11 +103,13 @@ class StringMaxLengthConstraintTest {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
             2,
-            1
+            1,
+            null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maxLength", 2, 1
@@ -115,11 +125,13 @@ class StringMaxLengthConstraintTest {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
             null,
-            1
+            1,
+            null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
             1,
-            1
+            1,
+            null
         );
         ConstraintChange expected = new ConstraintChange(
             "maxLength", null, 1

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/string/StringPatternConstraintTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/request/parameter/constraint/string/StringPatternConstraintTest.java
@@ -8,17 +8,17 @@ import com.docktape.swagger.brake.core.rule.request.parameter.constraint.Constra
 import com.docktape.swagger.brake.core.rule.request.parameter.constraint.StringConstrainedValue;
 import org.junit.jupiter.api.Test;
 
-class StringMinLengthConstraintTest {
-    private StringMinLengthConstraint underTest = new StringMinLengthConstraint();
+class StringPatternConstraintTest {
+    private StringPatternConstraint underTest = new StringPatternConstraint();
 
     @Test
     void testValidateConstraintsShouldReturnEmptyOptionalWhenNullOldRequestParamIsGiven() {
         // given
         StringConstrainedValue oldRequestParameter = null;
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
-            1,
-            1,
-            null
+            null,
+            null,
+            "[a-z]+"
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -30,9 +30,9 @@ class StringMinLengthConstraintTest {
     void testValidateConstraintsShouldReturnEmptyOptionalWhenNullNewRequestParamIsGiven() {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
-            1,
-            1,
-            null
+            null,
+            null,
+            "[a-z]+"
         );
         StringConstrainedValue newRequestParameter = null;
         // when
@@ -42,17 +42,17 @@ class StringMinLengthConstraintTest {
     }
 
     @Test
-    void testValidateConstraintsShouldReturnEmptyOptionalWhenRequestParameterIsNotStringTyped() {
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenPatternIsNotChanged() {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
-            1,
-            1,
-            null
+            null,
+            null,
+            "[a-z]+"
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
-            1,
-            1,
-            null
+            null,
+            null,
+            "[a-z]+"
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -61,34 +61,15 @@ class StringMinLengthConstraintTest {
     }
 
     @Test
-    void testValidateConstraintsShouldReturnEmptyOptionalWhenMinLengthIsExtended() {
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenBothPatternsAreNull() {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
-            1,
-            1,
+            null,
+            null,
             null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
-            1,
-            0,
-            null
-        );
-        // when
-        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
-        // then
-        assertThat(result).isNotPresent();
-    }
-
-    @Test
-    void testValidateConstraintsShouldReturnEmptyOptionalWhenMinLengthIsRemoved() {
-        // given
-        StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
-            1,
-            1,
-            null
-        );
-        StringConstrainedValue newRequestParameter = new StringConstrainedValue(
-            1,
+            null,
             null,
             null
         );
@@ -99,20 +80,39 @@ class StringMinLengthConstraintTest {
     }
 
     @Test
-    void testValidateConstraintsShouldReportConstraintChangeWhenMinLengthGetsLimited() {
+    void testValidateConstraintsShouldReturnEmptyOptionalWhenPatternIsRemoved() {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
-            5,
-            1,
+            null,
+            null,
+            "[a-z]+"
+        );
+        StringConstrainedValue newRequestParameter = new StringConstrainedValue(
+            null,
+            null,
+            null
+        );
+        // when
+        Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
+        // then
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    void testValidateConstraintsShouldReportConstraintChangeWhenPatternIsAdded() {
+        // given
+        StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
+            null,
+            null,
             null
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
-            5,
-            2,
-            null
+            null,
+            null,
+            "[a-z]+"
         );
         ConstraintChange expected = new ConstraintChange(
-            "minLength", 1, 2
+            "pattern", null, "[a-z]+"
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);
@@ -121,20 +121,20 @@ class StringMinLengthConstraintTest {
     }
 
     @Test
-    void testValidateConstraintsShouldReportConstraintChangeWhenMinLengthGetsSet() {
+    void testValidateConstraintsShouldReportConstraintChangeWhenPatternIsChanged() {
         // given
         StringConstrainedValue oldRequestParameter = new StringConstrainedValue(
-            1,
             null,
-            null
+            null,
+            "[a-z]+"
         );
         StringConstrainedValue newRequestParameter = new StringConstrainedValue(
-            1,
-            1,
-            null
+            null,
+            null,
+            "[A-Z]+"
         );
         ConstraintChange expected = new ConstraintChange(
-            "minLength", null, 1
+            "pattern", "[a-z]+", "[A-Z]+"
         );
         // when
         Optional<ConstraintChange> result = underTest.validateConstraints(oldRequestParameter, newRequestParameter);


### PR DESCRIPTION
Closes #208

## What changed

- `StringSchema`: added `pattern` field (populated from `schema.getPattern()` in `SchemaTransformer` and `SchemaBuilder`)
- `StringRequestParameter`: added `pattern` field (populated in `RequestParameterFactory`)
- `StringConstrainedValue`: added `pattern` field so constraint rules can access it
- `RequestParameterConstraintChangeRule`: passes `pattern` when constructing `StringConstrainedValue` from both schema and request-parameter paths
- New `StringPatternConstraint` (`@Component`): reports a breaking change when a pattern is **added** (old null, new non-null) or **changed** (both non-null but different); pattern **removed** is not flagged as it loosens the constraint

## Test plan

- [x] `./gradlew check` passes (checkstyle + SpotBugs + all tests)
- [x] `StringPatternConstraintTest` - pattern added -> breaking
- [x] `StringPatternConstraintTest` - pattern changed -> breaking
- [x] `StringPatternConstraintTest` - pattern removed -> not breaking
- [x] `StringPatternConstraintTest` - pattern unchanged -> not breaking
- [x] `StringPatternConstraintTest` - null old/new param -> not breaking
- [x] Existing `StringMaxLengthConstraintTest` and `StringMinLengthConstraintTest` updated to use new 3-arg constructor and still pass