### PR TITLE
feat(R035): detect server URL changes (opt-in rule)

### DIFF
--- a/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/CliOption.java
+++ b/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/CliOption.java
@@ -34,7 +34,11 @@ public enum CliOption {
     /**
      * Maximum depth for log serialization of Swagger/OpenAPI objects to prevent StackOverflowError with circular references.
      */
-    MAX_LOG_SERIALIZATION_DEPTH("max-log-serialization-depth");
+    MAX_LOG_SERIALIZATION_DEPTH("max-log-serialization-depth"),
+    /**
+     * Whether to enable detection of server URL changes. Defaults to false.
+     */
+    SERVER_URL_CHANGE_ENABLED("server-url-change-enabled");
 
     private final String cliOptionName;
 

--- a/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/handler/ServerUrlChangeEnabledHandler.java
+++ b/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/handler/ServerUrlChangeEnabledHandler.java
@@ -1,0 +1,27 @@
+package com.docktape.swagger.brake.cli.options.handler;
+
+import com.docktape.swagger.brake.cli.options.CliOption;
+import com.docktape.swagger.brake.runner.Options;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServerUrlChangeEnabledHandler implements CliOptionHandler {
+    @Override
+    public void handle(String optionValue, Options options) {
+        if (StringUtils.isNotBlank(optionValue)) {
+            options.setServerUrlChangeEnabled(BooleanUtils.toBooleanObject(optionValue));
+        }
+    }
+
+    @Override
+    public CliOption getHandledCliOption() {
+        return CliOption.SERVER_URL_CHANGE_ENABLED;
+    }
+
+    @Override
+    public String getHelpMessage() {
+        return "Whether to enable detection of server URL changes. Defaults to false.";
+    }
+}

--- a/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/ServerUrlChangeEnabledHandlerTest.java
+++ b/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/ServerUrlChangeEnabledHandlerTest.java
@@ -1,0 +1,70 @@
+package com.docktape.swagger.brake.cli.options.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.docktape.swagger.brake.runner.Options;
+import org.junit.jupiter.api.Test;
+
+class ServerUrlChangeEnabledHandlerTest {
+    private final ServerUrlChangeEnabledHandler underTest = new ServerUrlChangeEnabledHandler();
+
+    @Test
+    void testHandleShouldLeaveNullWhenNullValueGiven() {
+        // given
+        Options options = new Options();
+
+        // when
+        underTest.handle(null, options);
+
+        // then
+        assertThat(options.getServerUrlChangeEnabled()).isNull();
+    }
+
+    @Test
+    void testHandleShouldLeaveNullWhenEmptyValueGiven() {
+        // given
+        Options options = new Options();
+
+        // when
+        underTest.handle("", options);
+
+        // then
+        assertThat(options.getServerUrlChangeEnabled()).isNull();
+    }
+
+    @Test
+    void testHandleShouldSetTrueWhenTrueValueGiven() {
+        // given
+        Options options = new Options();
+
+        // when
+        underTest.handle("true", options);
+
+        // then
+        assertThat(options.getServerUrlChangeEnabled()).isTrue();
+    }
+
+    @Test
+    void testHandleShouldSetFalseWhenFalseValueGiven() {
+        // given
+        Options options = new Options();
+
+        // when
+        underTest.handle("false", options);
+
+        // then
+        assertThat(options.getServerUrlChangeEnabled()).isFalse();
+    }
+
+    @Test
+    void testHandleShouldLeaveNullWhenRandomValueGiven() {
+        // given
+        Options options = new Options();
+
+        // when
+        underTest.handle("random", options);
+
+        // then
+        assertThat(options.getServerUrlChangeEnabled()).isNull();
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/CheckerOptions.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/CheckerOptions.java
@@ -13,6 +13,7 @@ public class CheckerOptions {
     private boolean strictValidation = true;
     private int maxLogSerializationDepth = 3;
     private int maxSchemaTransformationDepth = 50;
+    private boolean serverUrlChangeEnabled = false;
 
     public void setMaxLogSerializationDepth(int maxLogSerializationDepth) {
         if (maxLogSerializationDepth < 1 || maxLogSerializationDepth > 20) {

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Specification.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Specification.java
@@ -1,6 +1,7 @@
 package com.docktape.swagger.brake.core.model;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import lombok.EqualsAndHashCode;
@@ -14,6 +15,7 @@ import lombok.ToString;
 @ToString
 public class Specification {
     private final Collection<Path> paths;
+    private final List<String> serverUrls;
 
     public Optional<Path> getPath(Path path) {
         return getPath(path.getPath(), path.getMethod());

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/OpenApiTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/OpenApiTransformer.java
@@ -1,11 +1,15 @@
 package com.docktape.swagger.brake.core.model.transformer;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.docktape.swagger.brake.core.model.Path;
 import com.docktape.swagger.brake.core.model.Specification;
 import com.docktape.swagger.brake.core.model.store.*;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,18 @@ public class OpenApiTransformer implements Transformer<OpenAPI, Specification> {
         } finally {
             StoreProvider.clear();
         }
-        return new Specification(paths);
+        List<String> serverUrls = extractServerUrls(from);
+        return new Specification(paths, serverUrls);
+    }
+
+    private List<String> extractServerUrls(OpenAPI from) {
+        List<Server> servers = from.getServers();
+        if (servers == null) {
+            return Collections.emptyList();
+        }
+        return servers.stream()
+            .map(Server::getUrl)
+            .filter(url -> url != null)
+            .collect(Collectors.toList());
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/server/ServerUrlChangedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/server/ServerUrlChangedBreakingChange.java
@@ -1,0 +1,25 @@
+package com.docktape.swagger.brake.core.rule.server;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ServerUrlChangedBreakingChange implements BreakingChange {
+    private final String oldUrl;
+
+    @Override
+    public String getMessage() {
+        return String.format("Server URL %s was removed or changed", oldUrl);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R035";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/server/ServerUrlChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/server/ServerUrlChangedRule.java
@@ -1,0 +1,41 @@
+package com.docktape.swagger.brake.core.rule.server;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.docktape.swagger.brake.core.CheckerOptions;
+import com.docktape.swagger.brake.core.CheckerOptionsProvider;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ServerUrlChangedRule implements BreakingChangeRule<ServerUrlChangedBreakingChange> {
+    private final CheckerOptionsProvider checkerOptionsProvider;
+
+    @Override
+    public Collection<ServerUrlChangedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        log.debug("Checking for server URL changes..");
+        CheckerOptions checkerOptions = checkerOptionsProvider.get();
+        if (!checkerOptions.isServerUrlChangeEnabled()) {
+            log.debug("Server URL change check is disabled, skipping");
+            return new ArrayList<>();
+        }
+        List<String> oldUrls = oldApi.getServerUrls();
+        List<String> newUrls = newApi.getServerUrls();
+        Collection<ServerUrlChangedBreakingChange> breakingChanges = new ArrayList<>();
+        for (String oldUrl : oldUrls) {
+            if (!newUrls.contains(oldUrl)) {
+                log.debug("Server URL {} is not present in the new API", oldUrl);
+                breakingChanges.add(new ServerUrlChangedBreakingChange(oldUrl));
+            }
+        }
+        log.debug("Found server URL changes: {}", breakingChanges);
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/CheckerOptionsFactory.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/CheckerOptionsFactory.java
@@ -20,6 +20,7 @@ public class CheckerOptionsFactory {
         checkerOptions.setExcludedPaths(options.getExcludedPaths());
         checkerOptions.setStrictValidation(isStrictValidationEnabled(options));
         checkerOptions.setMaxLogSerializationDepth(getMaxLogSerializationDepth(options, checkerOptions.getMaxLogSerializationDepth()));
+        checkerOptions.setServerUrlChangeEnabled(isServerUrlChangeEnabled(options));
         return checkerOptions;
     }
 
@@ -38,5 +39,9 @@ public class CheckerOptionsFactory {
     private int getMaxLogSerializationDepth(Options options, int defaultValue) {
         Integer maxDepth = options.getMaxLogSerializationDepth();
         return maxDepth != null ? maxDepth : defaultValue;
+    }
+
+    private boolean isServerUrlChangeEnabled(Options options) {
+        return BooleanUtils.toBooleanDefaultIfNull(options.getServerUrlChangeEnabled(), false);
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/Options.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/Options.java
@@ -30,4 +30,5 @@ public class Options {
     private Set<String> ignoredBreakingChangeRules = Collections.emptySet();
     private Boolean strictValidation;
     private Integer maxLogSerializationDepth;
+    private Boolean serverUrlChangeEnabled;
 }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/server/ServerUrlChangedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/server/ServerUrlChangedRuleTest.java
@@ -1,0 +1,132 @@
+package com.docktape.swagger.brake.core.rule.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import com.docktape.swagger.brake.core.CheckerOptions;
+import com.docktape.swagger.brake.core.CheckerOptionsProvider;
+import com.docktape.swagger.brake.core.model.Specification;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ServerUrlChangedRuleTest {
+    @Mock
+    private CheckerOptionsProvider checkerOptionsProvider;
+
+    @InjectMocks
+    private ServerUrlChangedRule underTest;
+
+    @Test
+    void testCheckRuleShouldReturnEmptyWhenServerUrlChangeIsDisabled() {
+        // given
+        CheckerOptions options = new CheckerOptions();
+        options.setServerUrlChangeEnabled(false);
+        given(checkerOptionsProvider.get()).willReturn(options);
+        Specification oldApi = specWithUrls(List.of("https://api.example.com"));
+        Specification newApi = specWithUrls(Collections.emptyList());
+
+        // when
+        Collection<ServerUrlChangedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testCheckRuleShouldReturnEmptyWhenAllOldUrlsArePresentInNewApi() {
+        // given
+        CheckerOptions options = new CheckerOptions();
+        options.setServerUrlChangeEnabled(true);
+        given(checkerOptionsProvider.get()).willReturn(options);
+        List<String> urls = Arrays.asList("https://api.example.com", "https://staging.example.com");
+        Specification oldApi = specWithUrls(urls);
+        Specification newApi = specWithUrls(urls);
+
+        // when
+        Collection<ServerUrlChangedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testCheckRuleShouldDetectRemovedServerUrl() {
+        // given
+        CheckerOptions options = new CheckerOptions();
+        options.setServerUrlChangeEnabled(true);
+        given(checkerOptionsProvider.get()).willReturn(options);
+        Specification oldApi = specWithUrls(Arrays.asList("https://api.example.com", "https://staging.example.com"));
+        Specification newApi = specWithUrls(List.of("https://staging.example.com"));
+
+        // when
+        Collection<ServerUrlChangedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).extracting(ServerUrlChangedBreakingChange::getOldUrl)
+            .containsExactly("https://api.example.com");
+    }
+
+    @Test
+    void testCheckRuleShouldDetectAllRemovedServerUrls() {
+        // given
+        CheckerOptions options = new CheckerOptions();
+        options.setServerUrlChangeEnabled(true);
+        given(checkerOptionsProvider.get()).willReturn(options);
+        Specification oldApi = specWithUrls(Arrays.asList("https://api.example.com", "https://staging.example.com"));
+        Specification newApi = specWithUrls(Collections.emptyList());
+
+        // when
+        Collection<ServerUrlChangedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(ServerUrlChangedBreakingChange::getOldUrl)
+            .containsExactlyInAnyOrder("https://api.example.com", "https://staging.example.com");
+    }
+
+    @Test
+    void testCheckRuleShouldReturnEmptyWhenOldApiHasNoServers() {
+        // given
+        CheckerOptions options = new CheckerOptions();
+        options.setServerUrlChangeEnabled(true);
+        given(checkerOptionsProvider.get()).willReturn(options);
+        Specification oldApi = specWithUrls(Collections.emptyList());
+        Specification newApi = specWithUrls(List.of("https://api.example.com"));
+
+        // when
+        Collection<ServerUrlChangedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testCheckRuleShouldNotFlagAddedServerUrls() {
+        // given
+        CheckerOptions options = new CheckerOptions();
+        options.setServerUrlChangeEnabled(true);
+        given(checkerOptionsProvider.get()).willReturn(options);
+        Specification oldApi = specWithUrls(List.of("https://api.example.com"));
+        Specification newApi = specWithUrls(Arrays.asList("https://api.example.com", "https://new.example.com"));
+
+        // when
+        Collection<ServerUrlChangedBreakingChange> result = underTest.checkRule(oldApi, newApi);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private Specification specWithUrls(List<String> urls) {
+        return new Specification(Collections.emptyList(), urls);
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/runner/CheckerOptionsFactoryTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/runner/CheckerOptionsFactoryTest.java
@@ -46,4 +46,43 @@ class CheckerOptionsFactoryTest {
         // then
         assertThat(result.isDeprecatedApiDeletionAllowed()).isFalse();
     }
+
+    @Test
+    void testCreateShouldLeaveFalseForServerUrlChangeEnabledWhenNullOptionGiven() {
+        // given
+        Options options = new Options();
+        options.setServerUrlChangeEnabled(null);
+
+        // when
+        CheckerOptions result = underTest.create(options);
+
+        // then
+        assertThat(result.isServerUrlChangeEnabled()).isFalse();
+    }
+
+    @Test
+    void testCreateShouldSetTrueForServerUrlChangeEnabledWhenTrueOptionGiven() {
+        // given
+        Options options = new Options();
+        options.setServerUrlChangeEnabled(true);
+
+        // when
+        CheckerOptions result = underTest.create(options);
+
+        // then
+        assertThat(result.isServerUrlChangeEnabled()).isTrue();
+    }
+
+    @Test
+    void testCreateShouldSetFalseForServerUrlChangeEnabledWhenFalseOptionGiven() {
+        // given
+        Options options = new Options();
+        options.setServerUrlChangeEnabled(false);
+
+        // when
+        CheckerOptions result = underTest.create(options);
+
+        // then
+        assertThat(result.isServerUrlChangeEnabled()).isFalse();
+    }
 }

--- a/swagger-brake/src/test/resources/swaggers/v3/server/petstore_server_url_removed.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/server/petstore_server_url_removed.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.1"
+info:
+  title: Petstore
+  version: "1.0"
+servers:
+  - url: https://staging.example.com/v1
+    description: Staging server
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/server/petstore_with_servers.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/server/petstore_with_servers.yaml
@@ -1,0 +1,23 @@
+openapi: "3.0.1"
+info:
+  title: Petstore
+  version: "1.0"
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+  - url: https://staging.example.com/v1
+    description: Staging server
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string


### PR DESCRIPTION
Closes #224

## What changed

- `Specification.java`: Added `List<String> serverUrls` field (never null, empty list if absent)
- `OpenApiTransformer.java`: Extracts server URLs from `OpenAPI.getServers()` and passes them to `Specification`
- `CheckerOptions.java`: Added `serverUrlChangeEnabled = false` (off by default)
- `Options.java`: Added `Boolean serverUrlChangeEnabled` for CLI/runner integration
- `CheckerOptionsFactory.java`: Maps `serverUrlChangeEnabled` from `Options` to `CheckerOptions`
- `ServerUrlChangedBreakingChange.java` (new, `rule/server/`): Breaking change with rule code R035
- `ServerUrlChangedRule.java` (new, `rule/server/`): Spring `@Component` rule that compares old vs new server URLs; skips check entirely if `serverUrlChangeEnabled=false`
- `CliOption.java`: Added `SERVER_URL_CHANGE_ENABLED("server-url-change-enabled")` enum value
- `ServerUrlChangeEnabledHandler.java` (new CLI handler): Maps `--server-url-change-enabled=true/false` to `Options`

## Test plan

- [x] `./gradlew check` passes (all checkstyle, SpotBugs, and tests green)
- [x] `ServerUrlChangedRuleTest`: URL removed when enabled -> flagged; when disabled -> not flagged; all URLs removed -> all flagged; added URLs -> not flagged; empty old servers -> empty result
- [x] `CheckerOptionsFactoryTest`: default is false, explicit true/false preserved
- [x] `ServerUrlChangeEnabledHandlerTest`: null/blank -> null option; true -> true; false -> false; random -> null