### PR TITLE
feat(R024): detect x-extensible-enum value removal

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ArraySchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ArraySchema.java
@@ -25,7 +25,7 @@ public class ArraySchema extends Schema {
      * @param uniqueItems the uniqueItems constraint
      */
     public ArraySchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema, Integer maxItems, Integer minItems, Boolean uniqueItems) {
-        super(type, enumValues, schemaAttributes, schema);
+        super(type, enumValues, schemaAttributes, schema, null);
         this.maxItems = maxItems;
         this.minItems = minItems;
         this.uniqueItems = uniqueItems;

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
@@ -59,7 +59,7 @@ public class NumberSchema extends Schema {
     @Deprecated
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, boolean exclusiveMaximum, boolean exclusiveMinimum) {
-        super(type, enumValues, schemaAttributes, schema);
+        super(type, enumValues, schemaAttributes, schema, null);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximum = exclusiveMaximum;
@@ -68,7 +68,7 @@ public class NumberSchema extends Schema {
         this.exclusiveMaximumValue = exclusiveMaximum && maximum != null ? maximum : null;
         this.exclusiveMinimumValue = exclusiveMinimum && minimum != null ? minimum : null;
     }
-    
+
     /**
      * Constructs a number schema with numeric exclusive bounds (OpenAPI 3.1.x).
      * @param type the type
@@ -82,7 +82,7 @@ public class NumberSchema extends Schema {
      */
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, BigDecimal exclusiveMaximumValue, BigDecimal exclusiveMinimumValue) {
-        super(type, enumValues, schemaAttributes, schema);
+        super(type, enumValues, schemaAttributes, schema, null);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximumValue = exclusiveMaximumValue;

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
@@ -29,6 +29,7 @@ public class Schema {
     private final Set<String> enumValues;
     private final Set<SchemaAttribute> schemaAttributes;
     private final Schema schema;
+    private final Set<String> extensibleEnum;
 
     public Optional<Schema> getSchema() {
         return Optional.ofNullable(schema);
@@ -45,6 +46,45 @@ public class Schema {
         }
         Collection<String> result = internalGetEnums(schemaAttrs, "");
         result.addAll(Optional.ofNullable(schema).map(Schema::getEnumValues).orElse(enumValues));
+        return result;
+    }
+
+    /**
+     * Returns all the x-extensible-enum values with attribute names recursively within the schema.
+     * @return map from attribute name (leveled) to its x-extensible-enum values.
+     */
+    public Map<String, Set<String>> getXExtensibleEnums() {
+        Collection<SchemaAttribute> schemaAttrs = schemaAttributes;
+        if (CollectionUtils.isEmpty(schemaAttrs)) {
+            schemaAttrs = Optional.ofNullable(schema).map(Schema::getSchemaAttributes).orElse(Collections.emptySet());
+        }
+        Map<String, Set<String>> result = internalGetXExtensibleEnums(schemaAttrs, "");
+        Set<String> rootExtEnum = Optional.ofNullable(schema)
+            .map(Schema::getExtensibleEnum)
+            .orElse(extensibleEnum);
+        if (rootExtEnum != null && !rootExtEnum.isEmpty()) {
+            result.put("", rootExtEnum);
+        }
+        return result;
+    }
+
+    private Map<String, Set<String>> internalGetXExtensibleEnums(Collection<SchemaAttribute> schemaAttributes, String levelName) {
+        Map<String, Set<String>> result = new HashMap<>();
+        for (SchemaAttribute schemaAttribute : schemaAttributes) {
+            Schema childSchema = schemaAttribute.getSchema();
+            if (childSchema != null) {
+                String attrName = generateLeveledName(schemaAttribute.getName(), levelName);
+                Set<String> extEnum = childSchema.getExtensibleEnum();
+                if (extEnum != null && !extEnum.isEmpty()) {
+                    result.put(attrName, extEnum);
+                }
+                Collection<SchemaAttribute> childSchemaAttributes = childSchema.getSchemaAttributes();
+                if (isEmpty(childSchemaAttributes)) {
+                    childSchemaAttributes = childSchema.getSchema().map(Schema::getSchemaAttributes).orElse(Collections.emptySet());
+                }
+                result.putAll(internalGetXExtensibleEnums(childSchemaAttributes, attrName));
+            }
+        }
         return result;
     }
 

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
@@ -3,6 +3,7 @@ package com.docktape.swagger.brake.core.model;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -39,6 +40,7 @@ public class SchemaBuilder {
 
     private BigDecimal exclusiveMaximumValue;
     private BigDecimal exclusiveMinimumValue;
+    private Set<String> extensibleEnum;
 
     public SchemaBuilder(String type) {
         this.type = type;
@@ -148,6 +150,16 @@ public class SchemaBuilder {
     }
 
     /**
+     * Sets the x-extensible-enum values.
+     * @param values the x-extensible-enum values
+     * @return this builder
+     */
+    public SchemaBuilder extensibleEnum(Set<String> values) {
+        this.extensibleEnum = values;
+        return this;
+    }
+
+    /**
      * Builds a {@link Schema} instance.
      * @return the constructed {@link Schema} instance.
      */
@@ -174,19 +186,19 @@ public class SchemaBuilder {
             schemaAttributes = new TreeSet<>(attributes);
         }
         if (AttributeType.getStringTypes().contains(attributeType)) {
-            return new StringSchema(type, enumValues, schemaAttributes, schema, maxLength, minLength);
+            return new StringSchema(type, enumValues, schemaAttributes, schema, maxLength, minLength, extensibleEnum);
         } else if (AttributeType.getNumberTypes().contains(attributeType)) {
             // Use numeric exclusive bounds if available, otherwise convert from boolean flags
-            BigDecimal effectiveExclusiveMax = exclusiveMaximumValue != null ? exclusiveMaximumValue 
+            BigDecimal effectiveExclusiveMax = exclusiveMaximumValue != null ? exclusiveMaximumValue
                 : (exclusiveMaximum && maximum != null ? maximum : null);
             BigDecimal effectiveExclusiveMin = exclusiveMinimumValue != null ? exclusiveMinimumValue
                 : (exclusiveMinimum && minimum != null ? minimum : null);
-            return new NumberSchema(type, enumValues, schemaAttributes, schema, maximum, minimum, 
+            return new NumberSchema(type, enumValues, schemaAttributes, schema, maximum, minimum,
                 effectiveExclusiveMax, effectiveExclusiveMin);
         } else if (AttributeType.getArrayTypes().contains(attributeType)) {
             return new ArraySchema(type, enumValues, schemaAttributes, schema, maxItems, minItems, uniqueItems);
         } else {
-            return new Schema(type, enumValues, schemaAttributes, schema);
+            return new Schema(type, enumValues, schemaAttributes, schema, extensibleEnum);
         }
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/StringSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/StringSchema.java
@@ -21,9 +21,11 @@ public class StringSchema extends Schema {
      * @param schema the underlying schema
      * @param maxLength the maxLength constraint
      * @param minLength the minLength constraint
+     * @param extEnum the x-extensible-enum values
      */
-    public StringSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema, Integer maxLength, Integer minLength) {
-        super(type, enumValues, schemaAttributes, schema);
+    public StringSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
+                        Integer maxLength, Integer minLength, Set<String> extEnum) {
+        super(type, enumValues, schemaAttributes, schema, extEnum);
         this.maxLength = maxLength;
         this.minLength = minLength;
     }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -157,6 +157,19 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
             List<String> enumValues = rawEnums.stream().filter(Objects::nonNull).map(Object::toString).toList();
             schemaBuilder.enumValues(enumValues);
         }
+        Map<String, Object> extensions = swSchema.getExtensions();
+        if (extensions != null) {
+            Object extEnumRaw = extensions.get("x-extensible-enum");
+            if (extEnumRaw instanceof List) {
+                java.util.Set<String> extEnumValues = new java.util.LinkedHashSet<>();
+                for (Object item : (List<?>) extEnumRaw) {
+                    if (item != null) {
+                        extEnumValues.add(item.toString());
+                    }
+                }
+                schemaBuilder.extensibleEnum(extEnumValues);
+            }
+        }
         return schemaBuilder.build();
     }
 

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestTypeXExtensibleEnumValueDeletedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestTypeXExtensibleEnumValueDeletedBreakingChange.java
@@ -1,0 +1,31 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestTypeXExtensibleEnumValueDeletedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String attributeName;
+    private final String enumValue;
+
+    @Override
+    public String getMessage() {
+        return format("%s was removed from x-extensible-enum of %s at %s %s", enumValue, attributeName, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R024";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestTypeXExtensibleEnumValueDeletedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestTypeXExtensibleEnumValueDeletedRule.java
@@ -1,0 +1,68 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Request;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestTypeXExtensibleEnumValueDeletedRule
+    implements BreakingChangeRule<RequestTypeXExtensibleEnumValueDeletedBreakingChange> {
+
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestTypeXExtensibleEnumValueDeletedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestTypeXExtensibleEnumValueDeletedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                Optional<Request> requestBody = path.getRequestBody();
+                Optional<Request> newRequestBody = newPath.getRequestBody();
+                if (requestBody.isPresent() && newRequestBody.isPresent()) {
+                    for (Map.Entry<MediaType, Schema> entry : requestBody.get().getMediaTypes().entrySet()) {
+                        MediaType mediaType = entry.getKey();
+                        Schema schema = entry.getValue();
+                        Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
+                        if (newApiSchema.isPresent()) {
+                            Map<String, Set<String>> oldXExtEnums = schema.getXExtensibleEnums();
+                            Map<String, Set<String>> newXExtEnums = newApiSchema.get().getXExtensibleEnums();
+                            for (Map.Entry<String, Set<String>> entry2 : oldXExtEnums.entrySet()) {
+                                String attributeName = entry2.getKey();
+                                Set<String> oldValues = entry2.getValue();
+                                Set<String> newValues = newXExtEnums.getOrDefault(attributeName, Set.of());
+                                for (String oldValue : oldValues) {
+                                    if (!newValues.contains(oldValue)) {
+                                        breakingChanges.add(
+                                            new RequestTypeXExtensibleEnumValueDeletedBreakingChange(
+                                                path.getPath(), path.getMethod(), attributeName, oldValue));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/request/RequestTypeXExtensibleEnumValueDeletedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/request/RequestTypeXExtensibleEnumValueDeletedIntTest.java
@@ -1,0 +1,46 @@
+package com.docktape.swagger.brake.integration.v2.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestTypeXExtensibleEnumValueDeletedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RequestTypeXExtensibleEnumValueDeletedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testXExtensibleEnumValueRemovedIsDetectedAsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v2/request/xextensibleenumvaluedeleted/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/xextensibleenumvaluedeleted/petstore_v2.yaml";
+        RequestTypeXExtensibleEnumValueDeletedBreakingChange expected =
+            new RequestTypeXExtensibleEnumValueDeletedBreakingChange("/order", HttpMethod.POST, "status", "approved");
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).contains(expected)
+        );
+    }
+
+    @Test
+    void testXExtensibleEnumValueAddedIsNotBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v2/request/xextensibleenumvaluedeleted/nobreakingchange/petstore.yaml";
+        String newApiPath = "swaggers/v2/request/xextensibleenumvaluedeleted/nobreakingchange/petstore_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).isEqualTo(Collections.emptyList());
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/nobreakingchange/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/nobreakingchange/petstore.yaml
@@ -1,0 +1,36 @@
+---
+swagger: "2.0"
+info:
+  description: "Test API for x-extensible-enum value deleted rule - no breaking change"
+  version: "1.0.0"
+  title: "Test API"
+host: "example.com"
+basePath: "/v1"
+schemes:
+- "https"
+paths:
+  /order:
+    post:
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      status:
+        type: "string"
+        x-extensible-enum:
+        - "placed"
+        - "approved"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/nobreakingchange/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/nobreakingchange/petstore_v2.yaml
@@ -1,0 +1,37 @@
+---
+swagger: "2.0"
+info:
+  description: "Test API for x-extensible-enum value deleted rule - no breaking change"
+  version: "2.0.0"
+  title: "Test API"
+host: "example.com"
+basePath: "/v1"
+schemes:
+- "https"
+paths:
+  /order:
+    post:
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      status:
+        type: "string"
+        x-extensible-enum:
+        - "placed"
+        - "approved"
+        - "delivered"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/petstore.yaml
@@ -1,0 +1,37 @@
+---
+swagger: "2.0"
+info:
+  description: "Test API for x-extensible-enum value deleted rule"
+  version: "1.0.0"
+  title: "Test API"
+host: "example.com"
+basePath: "/v1"
+schemes:
+- "https"
+paths:
+  /order:
+    post:
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      status:
+        type: "string"
+        x-extensible-enum:
+        - "placed"
+        - "approved"
+        - "delivered"

--- a/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v2/request/xextensibleenumvaluedeleted/petstore_v2.yaml
@@ -1,0 +1,36 @@
+---
+swagger: "2.0"
+info:
+  description: "Test API for x-extensible-enum value deleted rule"
+  version: "2.0.0"
+  title: "Test API"
+host: "example.com"
+basePath: "/v1"
+schemes:
+- "https"
+paths:
+  /order:
+    post:
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      status:
+        type: "string"
+        x-extensible-enum:
+        - "placed"
+        - "delivered"


### PR DESCRIPTION
Closes #215

## What changed

- Added `extensibleEnum` field to `Schema` (and subclasses `StringSchema`, `ArraySchema`, `NumberSchema`) populated at transform time from `schema.getExtensions().get("x-extensible-enum")` in `SchemaTransformer`
- Added `getXExtensibleEnums()` recursive method on `Schema` that returns a map of attribute-name to its x-extensible-enum values (mirroring the existing `getEnums()` pattern)
- Added `RequestTypeXExtensibleEnumValueDeletedBreakingChange` (rule code R024) with message format: `{value} was removed from x-extensible-enum of {attributeName} at {method} {path}`
- Added `RequestTypeXExtensibleEnumValueDeletedRule` as a Spring `@Component` that compares old and new request body schemas recursively

## Test plan

- [x] `./gradlew :swagger-brake:check` passes (checkstyle + spotbugs + tests)
- [x] `testXExtensibleEnumValueRemovedIsDetectedAsBreakingChange` - removing "approved" from x-extensible-enum is detected as R024
- [x] `testXExtensibleEnumValueAddedIsNotBreakingChange` - adding a value to x-extensible-enum is not flagged