### PR TITLE
feat(R022): detect required response property becoming optional

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameOptionalBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameOptionalBreakingChange.java
@@ -1,0 +1,31 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponsePropertyBecameOptionalBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String propertyName;
+
+    @Override
+    public String getMessage() {
+        return format("%s in response %s at %s %s is no longer required", propertyName, responseCode, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R022";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameOptionalRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyBecameOptionalRule.java
@@ -1,0 +1,56 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.*;
+
+import com.docktape.swagger.brake.core.model.*;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponsePropertyBecameOptionalRule implements BreakingChangeRule<ResponsePropertyBecameOptionalBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponsePropertyBecameOptionalBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponsePropertyBecameOptionalBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response apiResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(apiResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        for (Map.Entry<MediaType, Schema> entry : apiResponse.getMediaTypes().entrySet()) {
+                            MediaType mediaType = entry.getKey();
+                            Schema schema = entry.getValue();
+                            Optional<Schema> newApiSchema = newResponse.getSchemaByMediaType(mediaType);
+                            if (newApiSchema.isPresent()) {
+                                Schema newSchema = newApiSchema.get();
+                                Set<String> oldRequiredAttributes = schema.getRequiredAttributeNames();
+                                Set<String> newRequiredAttributes = newSchema.getRequiredAttributeNames();
+                                for (String oldRequired : oldRequiredAttributes) {
+                                    if (!newRequiredAttributes.contains(oldRequired)) {
+                                        breakingChanges.add(
+                                                new ResponsePropertyBecameOptionalBreakingChange(
+                                                        path.getPath(), path.getMethod(), apiResponse.getCode(), oldRequired));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/response/ResponsePropertyBecameOptionalIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v2/response/ResponsePropertyBecameOptionalIntTest.java
@@ -1,0 +1,45 @@
+package com.docktape.swagger.brake.integration.v2.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.response.ResponsePropertyBecameOptionalBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponsePropertyBecameOptionalIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testRequiredPropertyBecomingOptionalIsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/response/property-became-optional/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/property-became-optional/petstore_v2.yaml";
+        ResponsePropertyBecameOptionalBreakingChange expected = new ResponsePropertyBecameOptionalBreakingChange(
+                "/pet", HttpMethod.GET, "200", "name");
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result).contains(expected)
+        );
+    }
+
+    @Test
+    void testPropertyBecomingRequiredIsNotBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/response/property-became-required/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/property-became-required/petstore_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).doesNotHaveAnyElementsOfTypes(ResponsePropertyBecameOptionalBreakingChange.class);
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/response/property-became-optional/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/property-became-optional/petstore.yaml
@@ -1,0 +1,36 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - name
+        - id
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        tag:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/property-became-optional/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/property-became-optional/petstore_v2.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        tag:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/property-became-required/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/property-became-required/petstore.yaml
@@ -1,0 +1,35 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        tag:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/response/property-became-required/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/property-became-required/petstore_v2.yaml
@@ -1,0 +1,36 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        tag:
+          type: string


### PR DESCRIPTION
Closes #211

## What changed

Added `ResponsePropertyBecameOptionalRule` (R022) that detects when a property that was marked as `required` in a response schema becomes optional in the new API version. This is a breaking change because clients relying on that property always being present in the response will break.

Implementation follows the same pattern as `ResponseTypeAttributeRemovedRule`:
- `ResponsePropertyBecameOptionalBreakingChange` - the breaking change record with rule code R022
- `ResponsePropertyBecameOptionalRule` - Spring `@Component` that iterates paths/responses/media types and compares `getRequiredAttributeNames()` between old and new schemas

## Test plan

- [x] `./gradlew check` passes
- [x] `testRequiredPropertyBecomingOptionalIsBreakingChange` - removing `required` from a response property is detected as R022
- [x] `testPropertyBecomingRequiredIsNotBreakingChange` - adding `required` to a response property does NOT produce R022 findings