### PR TITLE
feat(engine): introduce ERROR/WARNING/INFO severity model

### DIFF
--- a/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/CliOption.java
+++ b/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/CliOption.java
@@ -38,7 +38,11 @@ public enum CliOption {
     /**
      * Whether to enable detection of server URL changes. Defaults to false.
      */
-    SERVER_URL_CHANGE_ENABLED("server-url-change-enabled");
+    SERVER_URL_CHANGE_ENABLED("server-url-change-enabled"),
+    /**
+     * Minimum severity level at which breaking changes cause a CI failure. Accepted values: error, warning, info.
+     */
+    FAIL_ON_SEVERITY("fail-on-severity");
 
     private final String cliOptionName;
 

--- a/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/handler/FailOnSeverityHandler.java
+++ b/swagger-brake-cli/src/main/java/com/docktape/swagger/brake/cli/options/handler/FailOnSeverityHandler.java
@@ -1,0 +1,36 @@
+package com.docktape.swagger.brake.cli.options.handler;
+
+import com.docktape.swagger.brake.cli.options.CliOption;
+import com.docktape.swagger.brake.core.Severity;
+import com.docktape.swagger.brake.runner.Options;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class FailOnSeverityHandler implements CliOptionHandler {
+    @Override
+    public void handle(String optionValue, Options options) {
+        if (StringUtils.isNotBlank(optionValue)) {
+            log.debug("Handling {} parameter with value {}", getHandledCliOption(), optionValue);
+            try {
+                Severity severity = Severity.valueOf(optionValue.trim().toUpperCase());
+                options.setFailOnSeverity(severity);
+            } catch (IllegalArgumentException e) {
+                log.warn("Invalid severity value '{}', keeping default ERROR", optionValue);
+            }
+        }
+    }
+
+    @Override
+    public CliOption getHandledCliOption() {
+        return CliOption.FAIL_ON_SEVERITY;
+    }
+
+    @Override
+    public String getHelpMessage() {
+        return "Specifies the minimum severity level at which breaking changes cause a CI failure. "
+                + "Accepted values: error, warning, info. Defaults to error.";
+    }
+}

--- a/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/FailOnSeverityHandlerTest.java
+++ b/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/FailOnSeverityHandlerTest.java
@@ -1,0 +1,87 @@
+package com.docktape.swagger.brake.cli.options.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.docktape.swagger.brake.cli.options.CliOption;
+import com.docktape.swagger.brake.core.Severity;
+import com.docktape.swagger.brake.runner.Options;
+import org.junit.jupiter.api.Test;
+
+class FailOnSeverityHandlerTest {
+    private final FailOnSeverityHandler underTest = new FailOnSeverityHandler();
+
+    @Test
+    void testHandleShouldSetErrorSeverityWhenValueIsError() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("error", options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.ERROR);
+    }
+
+    @Test
+    void testHandleShouldSetWarningSeverityWhenValueIsWarning() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("warning", options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.WARNING);
+    }
+
+    @Test
+    void testHandleShouldSetInfoSeverityWhenValueIsInfo() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("info", options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.INFO);
+    }
+
+    @Test
+    void testHandleShouldBeCaseInsensitive() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("WARNING", options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.WARNING);
+    }
+
+    @Test
+    void testHandleShouldKeepDefaultWhenValueIsNull() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle(null, options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.ERROR);
+    }
+
+    @Test
+    void testHandleShouldKeepDefaultWhenValueIsBlank() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("  ", options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.ERROR);
+    }
+
+    @Test
+    void testHandleShouldKeepDefaultWhenValueIsInvalid() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("invalid", options);
+        // then
+        assertThat(options.getFailOnSeverity()).isEqualTo(Severity.ERROR);
+    }
+
+    @Test
+    void testGetHandledCliOptionShouldReturnFailOnSeverity() {
+        assertThat(underTest.getHandledCliOption()).isEqualTo(CliOption.FAIL_ON_SEVERITY);
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/BreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/BreakingChange.java
@@ -4,4 +4,8 @@ public interface BreakingChange {
     String getMessage();
 
     String getRuleCode();
+
+    default Severity getSeverity() {
+        return Severity.ERROR;
+    }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/Severity.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/Severity.java
@@ -1,0 +1,7 @@
+package com.docktape.swagger.brake.core;
+
+public enum Severity {
+    ERROR,
+    WARNING,
+    INFO
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/report/StdOutReporter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/report/StdOutReporter.java
@@ -20,7 +20,7 @@ class StdOutReporter implements Reporter, CheckableReporter {
     private void printBreakingChangesIfAny(Collection<BreakingChange> breakingChanges) {
         if (!breakingChanges.isEmpty()) {
             System.err.println("There were breaking API changes");
-            breakingChanges.stream().map(bc -> bc.getRuleCode() + " " + bc.getMessage()).forEach(System.err::println);
+            breakingChanges.stream().map(bc -> "[" + bc.getSeverity() + "] " + bc.getRuleCode() + " " + bc.getMessage()).forEach(System.err::println);
         } else {
             System.out.println("No breaking API changes detected");
         }
@@ -29,7 +29,7 @@ class StdOutReporter implements Reporter, CheckableReporter {
     private void printIgnoredBreakingChangesIfAny(Collection<BreakingChange> ignoredBreakingChanges) {
         if (!ignoredBreakingChanges.isEmpty()) {
             System.out.println("There were ignored breaking API changes");
-            ignoredBreakingChanges.stream().map(bc -> bc.getRuleCode() + " " + bc.getMessage()).forEach(System.out::println);
+            ignoredBreakingChanges.stream().map(bc -> "[" + bc.getSeverity() + "] " + bc.getRuleCode() + " " + bc.getMessage()).forEach(System.out::println);
         }
     }
 

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/Options.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/Options.java
@@ -3,6 +3,7 @@ package com.docktape.swagger.brake.runner;
 import java.util.Collections;
 import java.util.Set;
 
+import com.docktape.swagger.brake.core.Severity;
 import lombok.Data;
 
 @Data
@@ -31,4 +32,5 @@ public class Options {
     private Boolean strictValidation;
     private Integer maxLogSerializationDepth;
     private Boolean serverUrlChangeEnabled;
+    private Severity failOnSeverity = Severity.ERROR;
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/Runner.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/Runner.java
@@ -1,6 +1,7 @@
 package com.docktape.swagger.brake.runner;
 
 import com.docktape.swagger.brake.core.ApiInfo;
+import com.docktape.swagger.brake.core.Severity;
 import com.docktape.swagger.brake.runner.openapi.ApiInfoFactory;
 import java.util.Collection;
 
@@ -57,8 +58,8 @@ public class Runner {
         Collection<BreakingChange> ignoredBreakingChanges = allBreakingChanges.stream().filter(bc -> isIgnoredBreakingChange(options, bc)).toList();
 
         ApiInfo apiInfo = apiInfoFactory.create(newApi);
-        reporterFactory.create(options).report(breakingChanges, options, apiInfo);
-        return breakingChanges;
+        reporterFactory.create(options).report(breakingChanges, ignoredBreakingChanges, options, apiInfo);
+        return breakingChanges.stream().filter(bc -> meetsFailOnSeverity(options.getFailOnSeverity(), bc.getSeverity())).toList();
     }
 
     private boolean isNotIgnoredBreakingChange(Options options, BreakingChange breakingChange) {
@@ -67,5 +68,9 @@ public class Runner {
 
     private boolean isIgnoredBreakingChange(Options options, BreakingChange breakingChange) {
         return options.getIgnoredBreakingChangeRules().contains(breakingChange.getRuleCode());
+    }
+
+    private boolean meetsFailOnSeverity(Severity failOnSeverity, Severity changeSeverity) {
+        return changeSeverity.ordinal() <= failOnSeverity.ordinal();
     }
 }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/SeverityTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/SeverityTest.java
@@ -1,0 +1,40 @@
+package com.docktape.swagger.brake.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.docktape.swagger.brake.core.rule.path.PathDeletedBreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import org.junit.jupiter.api.Test;
+
+class SeverityTest {
+
+    @Test
+    void testGetSeverityShouldReturnErrorByDefaultOnExistingBreakingChangeImpl() {
+        // given
+        BreakingChange breakingChange = new PathDeletedBreakingChange("/api/test", HttpMethod.GET);
+        // when
+        Severity severity = breakingChange.getSeverity();
+        // then
+        assertThat(severity).isEqualTo(Severity.ERROR);
+    }
+
+    @Test
+    void testGetSeverityShouldReturnErrorOnAnonymousImpl() {
+        // given
+        BreakingChange breakingChange = new BreakingChange() {
+            @Override
+            public String getMessage() {
+                return "test message";
+            }
+
+            @Override
+            public String getRuleCode() {
+                return "R999";
+            }
+        };
+        // when
+        Severity severity = breakingChange.getSeverity();
+        // then
+        assertThat(severity).isEqualTo(Severity.ERROR);
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
@@ -41,11 +41,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -72,7 +72,7 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> mediaTypes = new HashMap<>();
         mediaTypes.put(mediaType, schema);
-        Response response = new Response("200", mediaTypes);
+        Response response = new Response("200", mediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
@@ -96,12 +96,12 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(oldMediaType, schema);
         newMediaTypes.put(newGeneralMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -125,11 +125,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/report/StdOutReporterSeverityTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/report/StdOutReporterSeverityTest.java
@@ -1,0 +1,71 @@
+package com.docktape.swagger.brake.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.Severity;
+import com.docktape.swagger.brake.runner.Options;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StdOutReporterSeverityTest {
+    private final StdOutReporter underTest = new StdOutReporter();
+
+    private PrintStream originalErr;
+    private ByteArrayOutputStream errContent;
+
+    @BeforeEach
+    void setUp() throws UnsupportedEncodingException {
+        originalErr = System.err;
+        errContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errContent, true, StandardCharsets.UTF_8.name()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setErr(originalErr);
+    }
+
+    @Test
+    void testReportShouldIncludeSeverityInOutput() {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        given(bc.getRuleCode()).willReturn("R002");
+        given(bc.getMessage()).willReturn("Path /test GET has been deleted");
+        given(bc.getSeverity()).willReturn(Severity.ERROR);
+
+        Options options = new Options();
+        // when
+        underTest.report(List.of(bc), Collections.emptyList(), options, null);
+        // then
+        String output = errContent.toString(StandardCharsets.UTF_8);
+        assertThat(output).contains("[ERROR]");
+        assertThat(output).contains("R002");
+        assertThat(output).contains("Path /test GET has been deleted");
+    }
+
+    @Test
+    void testReportShouldIncludeWarningSeverityInOutput() {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        given(bc.getRuleCode()).willReturn("R002");
+        given(bc.getMessage()).willReturn("some warning change");
+        given(bc.getSeverity()).willReturn(Severity.WARNING);
+
+        Options options = new Options();
+        // when
+        underTest.report(List.of(bc), Collections.emptyList(), options, null);
+        // then
+        String output = errContent.toString(StandardCharsets.UTF_8);
+        assertThat(output).contains("[WARNING]");
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/runner/RunnerIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/runner/RunnerIntTest.java
@@ -111,7 +111,7 @@ class RunnerIntTest {
         verify(openApiFactory).fromFile(oldApiPath);
         verify(openApiFactory).fromFile(options.getNewApiPath());
         verify(checker).check(eq(oldApi), eq(newApi), any(CheckerOptions.class));
-        verify(reporter).report(anyList(), eq(options), any(ApiInfo.class));
+        verify(reporter).report(anyList(), anyList(), eq(options), any(ApiInfo.class));
     }
 
     @Test
@@ -152,6 +152,6 @@ class RunnerIntTest {
         verify(openApiFactory).fromFile(oldApiPath);
         verify(openApiFactory).fromFile(options.getNewApiPath());
         verify(checker).check(eq(oldApi), eq(newApi), any(CheckerOptions.class));
-        verify(reporter).report(anyList(), eq(options), any(ApiInfo.class));
+        verify(reporter).report(anyList(), anyList(), eq(options), any(ApiInfo.class));
     }
 }


### PR DESCRIPTION
Closes #227

## What changed

- Added `Severity` enum (`ERROR`, `WARNING`, `INFO`) in the core library
- Added a default `getSeverity()` method to `BreakingChange` returning `Severity.ERROR` - all existing implementations inherit ERROR without modification
- `StdOutReporter` now prefixes each breaking change line with `[SEVERITY]`
- JSON output gains a `severity` field automatically via Jackson's getter detection on the interface default method
- `Options.failOnSeverity` (default `ERROR`) controls which severity levels trigger a non-zero exit code; `Runner` filters the returned collection accordingly
- CLI `--fail-on-severity` option (accepted values: `error`, `warning`, `info`) wires this through via a new `FailOnSeverityHandler`

## Test plan

- [x] `./gradlew :swagger-brake:check :swagger-brake-cli:check` passes (Checkstyle, SpotBugs, and all unit tests)
- [x] `SeverityTest` verifies existing `BreakingChange` impls default to `ERROR` severity
- [x] `StdOutReporterSeverityTest` verifies `[ERROR]` / `[WARNING]` prefixes appear in output
- [x] `FailOnSeverityHandlerTest` verifies all valid values, case-insensitivity, null/blank/invalid handling
- [x] `RunnerIntTest` updated to match new `report(breakingChanges, ignoredBreakingChanges, options, apiInfo)` call signature