### PR TITLE
feat(R023): detect optional request body becoming required

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Request.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Request.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 @ToString
 public class Request {
     private final Map<MediaType, Schema> mediaTypes;
+    private final boolean required;
 
     public Optional<Schema> getSchemaByMediaType(MediaType mediaType) {
         return Optional.ofNullable(mediaTypes.get(mediaType));

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/RequestBodyTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/RequestBodyTransformer.java
@@ -11,6 +11,7 @@ import com.docktape.swagger.brake.core.model.Request;
 import com.docktape.swagger.brake.core.model.Schema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,11 +21,12 @@ public class RequestBodyTransformer implements Transformer<RequestBody, Request>
 
     @Override
     public Request transform(RequestBody from) {
+        boolean required = BooleanUtils.isTrue(from.getRequired());
         if (from.getContent() == null) {
-            return new Request(Collections.emptyMap());
+            return new Request(Collections.emptyMap(), required);
         }
         Set<Map.Entry<String, io.swagger.v3.oas.models.media.MediaType>> entries = from.getContent().entrySet();
         Map<MediaType, Schema> mediaTypes = entries.stream().collect(toMap(e -> new MediaType(e.getKey()), e -> mediaTypeTransformer.transform(e.getValue())));
-        return new Request(mediaTypes);
+        return new Request(mediaTypes, required);
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameRequiredBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameRequiredBreakingChange.java
@@ -1,0 +1,29 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestBodyBecameRequiredBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+
+    @Override
+    public String getMessage() {
+        return format("Request body became required at %s %s", method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R023";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameRequiredRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestBodyBecameRequiredRule.java
@@ -1,0 +1,46 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Request;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestBodyBecameRequiredRule implements BreakingChangeRule<RequestBodyBecameRequiredBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestBodyBecameRequiredBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestBodyBecameRequiredBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                Optional<Request> oldRequestBody = path.getRequestBody();
+                Optional<Request> newRequestBody = newPath.getRequestBody();
+                if (newRequestBody.isPresent() && newRequestBody.get().isRequired()) {
+                    boolean oldWasNotRequired = !oldRequestBody.isPresent() || !oldRequestBody.get().isRequired();
+                    if (oldWasNotRequired) {
+                        breakingChanges.add(new RequestBodyBecameRequiredBreakingChange(path.getPath(), path.getMethod()));
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/requestbody/becamerequired/V3RequestBodyBecameRequiredIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/requestbody/becamerequired/V3RequestBodyBecameRequiredIntTest.java
@@ -1,0 +1,54 @@
+package com.docktape.swagger.brake.integration.v3.request.requestbody.becamerequired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestBodyBecameRequiredBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class V3RequestBodyBecameRequiredIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testOptionalRequestBodyBecomingRequiredIsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/requestbody/becamerequired/optionaltorequired/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/requestbody/becamerequired/optionaltorequired/petstore_v2.yaml";
+        RequestBodyBecameRequiredBreakingChange expected = new RequestBodyBecameRequiredBreakingChange("/pet", HttpMethod.POST);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).contains(expected);
+    }
+
+    @Test
+    void testNoRequestBodyBecomingRequiredIsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/requestbody/becamerequired/nobodytorequired/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/requestbody/becamerequired/nobodytorequired/petstore_v2.yaml";
+        RequestBodyBecameRequiredBreakingChange expected = new RequestBodyBecameRequiredBreakingChange("/pet", HttpMethod.POST);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result).contains(expected);
+    }
+
+    @Test
+    void testOptionalRequestBodyRemainingOptionalIsNotBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/requestbody/becamerequired/nobreakingchange/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/requestbody/becamerequired/nobreakingchange/petstore_v2.yaml";
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertThat(result).doesNotHaveAnyElementsOfTypes(RequestBodyBecameRequiredBreakingChange.class);
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobodytorequired/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobodytorequired/petstore.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a new pet
+      operationId: addPet
+      responses:
+        '201':
+          description: Pet created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobodytorequired/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobodytorequired/petstore_v2.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a new pet
+      operationId: addPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobreakingchange/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobreakingchange/petstore.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a new pet
+      operationId: addPet
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobreakingchange/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/nobreakingchange/petstore_v2.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a new pet
+      operationId: addPet
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/optionaltorequired/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/optionaltorequired/petstore.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a new pet
+      operationId: addPet
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/optionaltorequired/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/requestbody/becamerequired/optionaltorequired/petstore_v2.yaml
@@ -1,0 +1,27 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    post:
+      summary: Add a new pet
+      operationId: addPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Pet created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
Closes #212

## What changed

- Added `required` field to the `Request` model class
- Updated `RequestBodyTransformer` to read the `required` flag from the OpenAPI spec (`RequestBody.getRequired()`) using `BooleanUtils.isTrue()`
- Added `RequestBodyBecameRequiredBreakingChange` (rule code R023) with message: `Request body became required at {method} {path}`
- Added `RequestBodyBecameRequiredRule` which flags a breaking change when:
  - A previously optional request body becomes required
  - A path that had no request body gains a required request body

## Test plan

- [x] `./gradlew check` passes (checkstyle, SpotBugs, all tests)
- [x] `testOptionalRequestBodyBecomingRequiredIsBreakingChange` - optional -> required flagged
- [x] `testNoRequestBodyBecomingRequiredIsBreakingChange` - no body -> required body flagged
- [x] `testOptionalRequestBodyRemainingOptionalIsNotBreakingChange` - optional -> optional not flagged