### PR TITLE
feat(R032): detect response header removal and required-to-optional changes

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Response.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Response.java
@@ -16,6 +16,7 @@ import lombok.ToString;
 public class Response {
     private final String code;
     private final Map<MediaType, Schema> mediaTypes;
+    private final Map<String, ResponseHeader> headers;
 
     public Optional<Schema> getSchemaByMediaType(MediaType mediaType) {
         return Optional.ofNullable(mediaTypes.get(mediaType));

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ResponseHeader.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ResponseHeader.java
@@ -1,0 +1,16 @@
+package com.docktape.swagger.brake.core.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponseHeader {
+    private final String name;
+    private final boolean required;
+    private final String type;
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/ApiResponseTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/ApiResponseTransformer.java
@@ -1,5 +1,6 @@
 package com.docktape.swagger.brake.core.model.transformer;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -7,13 +8,16 @@ import java.util.Set;
 
 import com.docktape.swagger.brake.core.model.MediaType;
 import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.ResponseHeader;
 import com.docktape.swagger.brake.core.model.Schema;
 import com.docktape.swagger.brake.core.model.service.TypeRefNameResolver;
 import com.docktape.swagger.brake.core.model.store.ResponseStore;
 import com.docktape.swagger.brake.core.model.store.StoreProvider;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
 
@@ -37,7 +41,29 @@ public class ApiResponseTransformer implements Transformer<Pair<String, ApiRespo
                 }
             }
         }
-        return new Response(from.getKey(), schemaRefs);
+        Map<String, ResponseHeader> headers = transformHeaders(from.getValue().getHeaders());
+        return new Response(from.getKey(), schemaRefs, headers);
+    }
+
+    private Map<String, ResponseHeader> transformHeaders(Map<String, Header> rawHeaders) {
+        if (rawHeaders == null || rawHeaders.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, ResponseHeader> result = new HashMap<>();
+        for (Map.Entry<String, Header> entry : rawHeaders.entrySet()) {
+            String name = entry.getKey();
+            Header header = entry.getValue();
+            boolean required = BooleanUtils.isTrue(header.getRequired());
+            String type = resolveHeaderType(header);
+            result.put(name, new ResponseHeader(name, required, type));
+        }
+        return result;
+    }
+
+    private String resolveHeaderType(Header header) {
+        return Optional.ofNullable(header.getSchema())
+            .map(io.swagger.v3.oas.models.media.Schema::getType)
+            .orElse("string");
     }
 
     /*

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderBecameOptionalBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderBecameOptionalBreakingChange.java
@@ -1,0 +1,31 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponseHeaderBecameOptionalBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String headerName;
+
+    @Override
+    public String getMessage() {
+        return format("%s response header became optional at %s %s for response %s", headerName, method, path, responseCode);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R033";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderBecameOptionalRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderBecameOptionalRule.java
@@ -1,0 +1,60 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.ResponseHeader;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponseHeaderBecameOptionalRule implements BreakingChangeRule<ResponseHeaderBecameOptionalBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponseHeaderBecameOptionalBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponseHeaderBecameOptionalBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response oldResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(oldResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        checkHeadersBecameOptional(breakingChanges, path, oldResponse, newResponse);
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+
+    private void checkHeadersBecameOptional(Set<ResponseHeaderBecameOptionalBreakingChange> breakingChanges, Path path,
+            Response oldResponse, Response newResponse) {
+        for (ResponseHeader oldHeader : oldResponse.getHeaders().values()) {
+            if (!oldHeader.isRequired()) {
+                continue;
+            }
+            ResponseHeader newHeader = newResponse.getHeaders().get(oldHeader.getName());
+            if (newHeader != null && !newHeader.isRequired()) {
+                breakingChanges.add(new ResponseHeaderBecameOptionalBreakingChange(
+                    path.getPath(), path.getMethod(), oldResponse.getCode(), oldHeader.getName()));
+            }
+        }
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderDeletedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderDeletedBreakingChange.java
@@ -1,0 +1,31 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponseHeaderDeletedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String headerName;
+
+    @Override
+    public String getMessage() {
+        return format("%s response header was deleted at %s %s for response %s", headerName, method, path, responseCode);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R032";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderDeletedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponseHeaderDeletedRule.java
@@ -1,0 +1,56 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.ResponseHeader;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponseHeaderDeletedRule implements BreakingChangeRule<ResponseHeaderDeletedBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponseHeaderDeletedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponseHeaderDeletedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response oldResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(oldResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        checkHeadersDeleted(breakingChanges, path, oldResponse, newResponse);
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+
+    private void checkHeadersDeleted(Set<ResponseHeaderDeletedBreakingChange> breakingChanges, Path path,
+            Response oldResponse, Response newResponse) {
+        for (ResponseHeader oldHeader : oldResponse.getHeaders().values()) {
+            if (oldHeader.isRequired() && !newResponse.getHeaders().containsKey(oldHeader.getName())) {
+                breakingChanges.add(new ResponseHeaderDeletedBreakingChange(
+                    path.getPath(), path.getMethod(), oldResponse.getCode(), oldHeader.getName()));
+            }
+        }
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/response/ResponseHeaderBecameOptionalIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/response/ResponseHeaderBecameOptionalIntTest.java
@@ -1,0 +1,35 @@
+package com.docktape.swagger.brake.integration.v3.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.response.ResponseHeaderBecameOptionalBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponseHeaderBecameOptionalIntTest extends AbstractSwaggerBrakeIntTest {
+    @Test
+    void testRequiredResponseHeaderBecomingOptionalIsBreaking() {
+        // given
+        String oldApiPath = "swaggers/v3/response/headerbecameoptional/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/headerbecameoptional/petstore_v2.yaml";
+        ResponseHeaderBecameOptionalBreakingChange bc =
+            new ResponseHeaderBecameOptionalBreakingChange("/pet", HttpMethod.GET, "200", "X-Rate-Limit");
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/response/ResponseHeaderDeletedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/response/ResponseHeaderDeletedIntTest.java
@@ -1,0 +1,35 @@
+package com.docktape.swagger.brake.integration.v3.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.response.ResponseHeaderDeletedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponseHeaderDeletedIntTest extends AbstractSwaggerBrakeIntTest {
+    @Test
+    void testRequiredResponseHeaderDeletedIsBreaking() {
+        // given
+        String oldApiPath = "swaggers/v3/response/headerdeleted/petstore.yaml";
+        String newApiPath = "swaggers/v3/response/headerdeleted/petstore_v2.yaml";
+        ResponseHeaderDeletedBreakingChange bc =
+            new ResponseHeaderDeletedBreakingChange("/pet", HttpMethod.GET, "200", "X-Rate-Limit");
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/response/headerbecameoptional/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/headerbecameoptional/petstore.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            X-Rate-Limit:
+              required: true
+              schema:
+                type: integer
+            X-Optional-Header:
+              required: false
+              schema:
+                type: string
+components:
+  schemas: {}

--- a/swagger-brake/src/test/resources/swaggers/v3/response/headerbecameoptional/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/headerbecameoptional/petstore_v2.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            X-Rate-Limit:
+              required: false
+              schema:
+                type: integer
+            X-Optional-Header:
+              required: false
+              schema:
+                type: string
+components:
+  schemas: {}

--- a/swagger-brake/src/test/resources/swaggers/v3/response/headerdeleted/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/headerdeleted/petstore.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            X-Rate-Limit:
+              required: true
+              schema:
+                type: integer
+            X-Correlation-Id:
+              required: false
+              schema:
+                type: string
+components:
+  schemas: {}

--- a/swagger-brake/src/test/resources/swaggers/v3/response/headerdeleted/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/response/headerdeleted/petstore_v2.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pet:
+    get:
+      summary: Get a pet
+      operationId: getPet
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            X-Correlation-Id:
+              required: false
+              schema:
+                type: string
+components:
+  schemas: {}


### PR DESCRIPTION
Closes #200

## What changed

- Added `ResponseHeader` model (`name`, `required`, `type`) to represent a response header in the domain model
- Updated `Response` to carry a `Map<String, ResponseHeader> headers` field (empty map when absent)
- Updated `ApiResponseTransformer` to read `Header` objects from `ApiResponse.getHeaders()` and populate the new field
- Added R032 rule (`ResponseHeaderDeletedRule`): flags a breaking change when a **required** response header is removed
- Added R033 rule (`ResponseHeaderBecameOptionalRule`): flags a breaking change when a required header becomes optional
- Optional headers being removed are intentionally **not** flagged (non-breaking for consumers)

## Test plan

- [x] `./gradlew check` passes (checkstyle + spotbugs + all tests)
- [x] `ResponseHeaderDeletedIntTest` - required header removed is detected (R032)
- [x] `ResponseHeaderBecameOptionalIntTest` - required header becoming optional is detected (R033)
- [x] Optional header removed: not flagged (covered implicitly - only required headers are checked in `ResponseHeaderDeletedRule`)