### PR TITLE
feat(R030): detect const constraint changes (OpenAPI 3.1)

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ArraySchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/ArraySchema.java
@@ -23,9 +23,11 @@ public class ArraySchema extends Schema {
      * @param maxItems the maxItems constraint
      * @param minItems the minItems constraint
      * @param uniqueItems the uniqueItems constraint
+     * @param constValue the const value (nullable)
      */
-    public ArraySchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema, Integer maxItems, Integer minItems, Boolean uniqueItems) {
-        super(type, enumValues, schemaAttributes, schema, null);
+    public ArraySchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes,
+            Schema schema, Integer maxItems, Integer minItems, Boolean uniqueItems, String constValue) {
+        super(type, enumValues, schemaAttributes, schema, null, constValue);
         this.maxItems = maxItems;
         this.minItems = minItems;
         this.uniqueItems = uniqueItems;

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/NumberSchema.java
@@ -60,7 +60,7 @@ public class NumberSchema extends Schema {
     @Deprecated
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, boolean exclusiveMaximum, boolean exclusiveMinimum) {
-        super(type, enumValues, schemaAttributes, schema, null);
+        super(type, enumValues, schemaAttributes, schema, null, null);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximum = exclusiveMaximum;
@@ -102,7 +102,7 @@ public class NumberSchema extends Schema {
     public NumberSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
                         BigDecimal maximum, BigDecimal minimum, BigDecimal exclusiveMaximumValue, BigDecimal exclusiveMinimumValue,
                         BigDecimal multipleOf) {
-        super(type, enumValues, schemaAttributes, schema, null);
+        super(type, enumValues, schemaAttributes, schema, null, null);
         this.maximum = maximum;
         this.minimum = minimum;
         this.exclusiveMaximumValue = exclusiveMaximumValue;

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/Schema.java
@@ -30,6 +30,7 @@ public class Schema {
     private final Set<SchemaAttribute> schemaAttributes;
     private final Schema schema;
     private final Set<String> extensibleEnum;
+    private final String constValue;
 
     public Optional<Schema> getSchema() {
         return Optional.ofNullable(schema);

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/SchemaBuilder.java
@@ -42,6 +42,7 @@ public class SchemaBuilder {
     private BigDecimal exclusiveMinimumValue;
     private Set<String> extensibleEnum;
     private BigDecimal multipleOf;
+    private String constValue;
 
     public SchemaBuilder(String type) {
         this.type = type;
@@ -171,6 +172,16 @@ public class SchemaBuilder {
     }
 
     /**
+     * Sets the const value (OpenAPI 3.1.x / JSON Schema).
+     * @param constValue the const value (nullable)
+     * @return this builder
+     */
+    public SchemaBuilder constValue(String constValue) {
+        this.constValue = constValue;
+        return this;
+    }
+
+    /**
      * Builds a {@link Schema} instance.
      * @return the constructed {@link Schema} instance.
      */
@@ -197,7 +208,7 @@ public class SchemaBuilder {
             schemaAttributes = new TreeSet<>(attributes);
         }
         if (AttributeType.getStringTypes().contains(attributeType)) {
-            return new StringSchema(type, enumValues, schemaAttributes, schema, maxLength, minLength, extensibleEnum);
+            return new StringSchema(type, enumValues, schemaAttributes, schema, maxLength, minLength, extensibleEnum, constValue);
         } else if (AttributeType.getNumberTypes().contains(attributeType)) {
             // Use numeric exclusive bounds if available, otherwise convert from boolean flags
             BigDecimal effectiveExclusiveMax = exclusiveMaximumValue != null ? exclusiveMaximumValue
@@ -207,9 +218,9 @@ public class SchemaBuilder {
             return new NumberSchema(type, enumValues, schemaAttributes, schema, maximum, minimum,
                 effectiveExclusiveMax, effectiveExclusiveMin, multipleOf);
         } else if (AttributeType.getArrayTypes().contains(attributeType)) {
-            return new ArraySchema(type, enumValues, schemaAttributes, schema, maxItems, minItems, uniqueItems);
+            return new ArraySchema(type, enumValues, schemaAttributes, schema, maxItems, minItems, uniqueItems, constValue);
         } else {
-            return new Schema(type, enumValues, schemaAttributes, schema, extensibleEnum);
+            return new Schema(type, enumValues, schemaAttributes, schema, extensibleEnum, constValue);
         }
     }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/StringSchema.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/StringSchema.java
@@ -22,10 +22,11 @@ public class StringSchema extends Schema {
      * @param maxLength the maxLength constraint
      * @param minLength the minLength constraint
      * @param extEnum the x-extensible-enum values
+     * @param constValue the const value (nullable)
      */
     public StringSchema(String type, Set<String> enumValues, Set<SchemaAttribute> schemaAttributes, Schema schema,
-                        Integer maxLength, Integer minLength, Set<String> extEnum) {
-        super(type, enumValues, schemaAttributes, schema, extEnum);
+                        Integer maxLength, Integer minLength, Set<String> extEnum, String constValue) {
+        super(type, enumValues, schemaAttributes, schema, extEnum, constValue);
         this.maxLength = maxLength;
         this.minLength = minLength;
     }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/transformer/SchemaTransformer.java
@@ -172,6 +172,10 @@ public class SchemaTransformer implements Transformer<io.swagger.v3.oas.models.m
                 schemaBuilder.extensibleEnum(extEnumValues);
             }
         }
+        Object constObj = swSchema.getConst();
+        if (constObj != null) {
+            schemaBuilder.constValue(constObj.toString());
+        }
         return schemaBuilder.build();
     }
 

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyConstChangedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyConstChangedBreakingChange.java
@@ -1,0 +1,32 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class RequestPropertyConstChangedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String propertyName;
+    private final String oldConst;
+    private final String newConst;
+
+    @Override
+    public String getMessage() {
+        return format("const of %s changed at %s %s", propertyName, method, path);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R030";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyConstChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/request/RequestPropertyConstChangedRule.java
@@ -1,0 +1,80 @@
+package com.docktape.swagger.brake.core.rule.request;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Request;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RequestPropertyConstChangedRule implements BreakingChangeRule<RequestPropertyConstChangedBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<RequestPropertyConstChangedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<RequestPropertyConstChangedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                Optional<Request> requestBody = path.getRequestBody();
+                Optional<Request> newRequestBody = newPath.getRequestBody();
+                if (requestBody.isPresent() && newRequestBody.isPresent()) {
+                    for (Map.Entry<MediaType, Schema> entry : requestBody.get().getMediaTypes().entrySet()) {
+                        MediaType mediaType = entry.getKey();
+                        Schema oldSchema = entry.getValue();
+                        Optional<Schema> newApiSchema = newRequestBody.get().getSchemaByMediaType(mediaType);
+                        if (newApiSchema.isPresent()) {
+                            Schema newSchema = newApiSchema.get();
+                            Map<String, Schema> oldSchemas = oldSchema.getSchemasRecursively();
+                            Map<String, Schema> newSchemas = newSchema.getSchemasRecursively();
+                            for (Map.Entry<String, Schema> schemaEntry : oldSchemas.entrySet()) {
+                                String propertyName = schemaEntry.getKey();
+                                String oldConst = schemaEntry.getValue().getConstValue();
+                                Schema newPropertySchema = newSchemas.get(propertyName);
+                                if (newPropertySchema == null) {
+                                    continue;
+                                }
+                                String newConst = newPropertySchema.getConstValue();
+                                if (isConstBreaking(oldConst, newConst)) {
+                                    breakingChanges.add(new RequestPropertyConstChangedBreakingChange(
+                                        path.getPath(), path.getMethod(), propertyName, oldConst, newConst));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+
+    private boolean isConstBreaking(String oldConst, String newConst) {
+        if (oldConst == null && newConst != null) {
+            // const added -> breaking (narrows to a single allowed value)
+            return true;
+        }
+        if (oldConst != null && newConst != null && !oldConst.equals(newConst)) {
+            // const changed -> breaking
+            return true;
+        }
+        return false;
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyConstChangedBreakingChange.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyConstChangedBreakingChange.java
@@ -1,0 +1,31 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import static java.lang.String.format;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class ResponsePropertyConstChangedBreakingChange implements BreakingChange {
+    private final String path;
+    private final HttpMethod method;
+    private final String responseCode;
+    private final String propertyName;
+
+    @Override
+    public String getMessage() {
+        return format("const of %s changed at %s %s for response %s", propertyName, method, path, responseCode);
+    }
+
+    @Override
+    public String getRuleCode() {
+        return "R031";
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyConstChangedRule.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/rule/response/ResponsePropertyConstChangedRule.java
@@ -1,0 +1,73 @@
+package com.docktape.swagger.brake.core.rule.response;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.docktape.swagger.brake.core.model.MediaType;
+import com.docktape.swagger.brake.core.model.Path;
+import com.docktape.swagger.brake.core.model.Response;
+import com.docktape.swagger.brake.core.model.Schema;
+import com.docktape.swagger.brake.core.model.Specification;
+import com.docktape.swagger.brake.core.rule.BreakingChangeRule;
+import com.docktape.swagger.brake.core.rule.PathSkipper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ResponsePropertyConstChangedRule implements BreakingChangeRule<ResponsePropertyConstChangedBreakingChange> {
+    private final PathSkipper pathSkipper;
+
+    @Override
+    public Collection<ResponsePropertyConstChangedBreakingChange> checkRule(Specification oldApi, Specification newApi) {
+        Set<ResponsePropertyConstChangedBreakingChange> breakingChanges = new HashSet<>();
+        for (Path path : oldApi.getPaths()) {
+            if (pathSkipper.shouldSkip(path)) {
+                log.debug("Skipping {} as it's marked as a beta API", path);
+                continue;
+            }
+            Optional<Path> newApiPath = newApi.getPath(path);
+            if (newApiPath.isPresent()) {
+                Path newPath = newApiPath.get();
+                for (Response apiResponse : path.getResponses()) {
+                    Optional<Response> newApiResponse = newPath.getResponseByCode(apiResponse.getCode());
+                    if (newApiResponse.isPresent()) {
+                        Response newResponse = newApiResponse.get();
+                        for (Map.Entry<MediaType, Schema> entry : apiResponse.getMediaTypes().entrySet()) {
+                            MediaType mediaType = entry.getKey();
+                            Schema oldSchema = entry.getValue();
+                            Optional<Schema> newApiSchema = newResponse.getSchemaByMediaType(mediaType);
+                            if (newApiSchema.isPresent()) {
+                                Schema newSchema = newApiSchema.get();
+                                Map<String, Schema> oldSchemas = oldSchema.getSchemasRecursively();
+                                Map<String, Schema> newSchemas = newSchema.getSchemasRecursively();
+                                for (Map.Entry<String, Schema> schemaEntry : oldSchemas.entrySet()) {
+                                    String propertyName = schemaEntry.getKey();
+                                    String oldConst = schemaEntry.getValue().getConstValue();
+                                    if (oldConst == null) {
+                                        continue;
+                                    }
+                                    Schema newPropertySchema = newSchemas.get(propertyName);
+                                    if (newPropertySchema == null) {
+                                        continue;
+                                    }
+                                    String newConst = newPropertySchema.getConstValue();
+                                    if (!oldConst.equals(newConst)) {
+                                        breakingChanges.add(new ResponsePropertyConstChangedBreakingChange(
+                                            path.getPath(), path.getMethod(), apiResponse.getCode(), propertyName));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return breakingChanges;
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
@@ -41,11 +41,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -72,7 +72,7 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> mediaTypes = new HashMap<>();
         mediaTypes.put(mediaType, schema);
-        Response response = new Response("200", mediaTypes);
+        Response response = new Response("200", mediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
@@ -96,12 +96,12 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(oldMediaType, schema);
         newMediaTypes.put(newGeneralMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -125,11 +125,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/openapi31/RequestPropertyConstChangedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/openapi31/RequestPropertyConstChangedIntTest.java
@@ -1,0 +1,36 @@
+package com.docktape.swagger.brake.integration.v3.openapi31;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestPropertyConstChangedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RequestPropertyConstChangedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testRequestConstAddedIsBreaking() {
+        String oldApiPath = "swaggers/v3/openapi31x/const-request/petstore_v1.json";
+        String newApiPath = "swaggers/v3/openapi31x/const-request/petstore_v2.json";
+        RequestPropertyConstChangedBreakingChange constAdded =
+            new RequestPropertyConstChangedBreakingChange("/orders", HttpMethod.POST, "status", null, "pending");
+        RequestPropertyConstChangedBreakingChange constChanged =
+            new RequestPropertyConstChangedBreakingChange("/orders", HttpMethod.POST, "source", "web", "mobile");
+
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+
+        assertAll(
+            () -> assertThat(result).hasSize(2),
+            () -> assertThat(result).contains(constAdded),
+            () -> assertThat(result).contains(constChanged)
+        );
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/openapi31/ResponsePropertyConstChangedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/openapi31/ResponsePropertyConstChangedIntTest.java
@@ -1,0 +1,43 @@
+package com.docktape.swagger.brake.integration.v3.openapi31;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.response.ResponsePropertyConstChangedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class ResponsePropertyConstChangedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testResponseConstChangedIsBreaking() {
+        String oldApiPath = "swaggers/v3/openapi31x/const-response/petstore_v1.json";
+        String newApiPath = "swaggers/v3/openapi31x/const-response/petstore_v2.json";
+        ResponsePropertyConstChangedBreakingChange expected =
+            new ResponsePropertyConstChangedBreakingChange("/orders/{id}", HttpMethod.GET, "200", "currency");
+
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+
+        assertAll(
+            () -> assertThat(result).hasSize(1),
+            () -> assertThat(result).contains(expected)
+        );
+    }
+
+    @Test
+    void testResponseConstUnchangedIsNotBreaking() {
+        String oldApiPath = "swaggers/v3/openapi31x/const-unchanged/petstore_v1.json";
+        String newApiPath = "swaggers/v3/openapi31x/const-unchanged/petstore_v2.json";
+
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-request/petstore_v1.json
+++ b/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-request/petstore_v1.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API for const request changes",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/orders": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "const": "web"
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-request/petstore_v2.json
+++ b/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-request/petstore_v2.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API for const request changes",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/orders": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "pending"
+          },
+          "source": {
+            "type": "string",
+            "const": "mobile"
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-response/petstore_v1.json
+++ b/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-response/petstore_v1.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API for const response changes",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/orders/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string",
+            "const": "USD"
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-response/petstore_v2.json
+++ b/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-response/petstore_v2.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API for const response changes",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/orders/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string",
+            "const": "EUR"
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-unchanged/petstore_v1.json
+++ b/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-unchanged/petstore_v1.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API for const unchanged",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/orders/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "currency": {
+            "type": "string",
+            "const": "USD"
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-unchanged/petstore_v2.json
+++ b/swagger-brake/src/test/resources/swaggers/v3/openapi31x/const-unchanged/petstore_v2.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API for const unchanged",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/orders/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "currency": {
+            "type": "string",
+            "const": "USD"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #219

## What changed

- Added `constValue` (nullable `String`) field to `Schema` and all subclasses (`StringSchema`, `NumberSchema`, `ArraySchema`), with a `constValue(String)` builder method on `SchemaBuilder`
- `SchemaTransformer` now calls `swSchema.getConst()` and stores the result via the builder
- **R030** (`RequestPropertyConstChangedBreakingChange` + `RequestPropertyConstChangedRule`): flags a breaking change when a request schema property has `const` added (narrows accepted values to one) or the `const` value changes
- **R031** (`ResponsePropertyConstChangedBreakingChange` + `ResponsePropertyConstChangedRule`): flags a breaking change when a response schema property has its `const` value changed or removed (clients coded to the previous single value)

## Test plan

- [x] `./gradlew :swagger-brake:check` passes (checkstyle + spotbugs + tests)
- [x] `RequestPropertyConstChangedIntTest` - verifies const added and const changed on request body are both flagged as R030
- [x] `ResponsePropertyConstChangedIntTest` - verifies const changed on response is flagged as R031, and const unchanged produces no breaking change