### PR TITLE
feat(A6): support cookie parameters in breaking change detection

### DIFF
--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/RequestParameterInType.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/core/model/RequestParameterInType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum RequestParameterInType {
     QUERY("query"),
     PATH("path"),
-    HEADER("header");
+    HEADER("header"),
+    COOKIE("cookie");
 
     private final String name;
 

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/model/RequestParameterInTypeTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/model/RequestParameterInTypeTest.java
@@ -1,0 +1,39 @@
+package com.docktape.swagger.brake.core.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RequestParameterInTypeTest {
+
+    @Test
+    void testFromNameReturnsCookieForCookieString() {
+        RequestParameterInType result = RequestParameterInType.fromName("cookie");
+        assertThat(result).isEqualTo(RequestParameterInType.COOKIE);
+    }
+
+    @Test
+    void testFromNameReturnsQueryForQueryString() {
+        RequestParameterInType result = RequestParameterInType.fromName("query");
+        assertThat(result).isEqualTo(RequestParameterInType.QUERY);
+    }
+
+    @Test
+    void testFromNameReturnsPathForPathString() {
+        RequestParameterInType result = RequestParameterInType.fromName("path");
+        assertThat(result).isEqualTo(RequestParameterInType.PATH);
+    }
+
+    @Test
+    void testFromNameReturnsHeaderForHeaderString() {
+        RequestParameterInType result = RequestParameterInType.fromName("header");
+        assertThat(result).isEqualTo(RequestParameterInType.HEADER);
+    }
+
+    @Test
+    void testFromNameThrowsForUnknownName() {
+        assertThatThrownBy(() -> RequestParameterInType.fromName("unknown"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/cookieparameterdeleted/CookieParameterDeletedIntTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/integration/v3/request/cookieparameterdeleted/CookieParameterDeletedIntTest.java
@@ -1,0 +1,45 @@
+package com.docktape.swagger.brake.integration.v3.request.cookieparameterdeleted;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.core.model.HttpMethod;
+import com.docktape.swagger.brake.core.rule.request.RequestParameterDeletedBreakingChange;
+import com.docktape.swagger.brake.integration.AbstractSwaggerBrakeIntTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class CookieParameterDeletedIntTest extends AbstractSwaggerBrakeIntTest {
+
+    @Test
+    void testRequiredCookieParameterDeletedIsBreakingChange() {
+        // given
+        String oldApiPath = "swaggers/v3/request/cookieparameterdeleted/petstore.yaml";
+        String newApiPath = "swaggers/v3/request/cookieparameterdeleted/petstore_v2.yaml";
+        RequestParameterDeletedBreakingChange bc = new RequestParameterDeletedBreakingChange("/pets", HttpMethod.GET, "session_id");
+        Collection<BreakingChange> expected = Collections.singleton(bc);
+        // when
+        Collection<BreakingChange> result = execute(oldApiPath, newApiPath);
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result).hasSameElementsAs(expected)
+        );
+    }
+
+    @Test
+    void testCookieParameterUnchangedIsNotBreakingChange() {
+        // given
+        String apiPath = "swaggers/v3/request/cookieparameterdeleted/petstore.yaml";
+        // when
+        Collection<BreakingChange> result = execute(apiPath, apiPath);
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/swagger-brake/src/test/resources/swaggers/v3/request/cookieparameterdeleted/petstore.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/cookieparameterdeleted/petstore.yaml
@@ -1,0 +1,37 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      parameters:
+        - name: session_id
+          in: cookie
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/swagger-brake/src/test/resources/swaggers/v3/request/cookieparameterdeleted/petstore_v2.yaml
+++ b/swagger-brake/src/test/resources/swaggers/v3/request/cookieparameterdeleted/petstore_v2.yaml
@@ -1,0 +1,31 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string


### PR DESCRIPTION
## Summary

- Adds `COOKIE("cookie")` as the 4th value in the `RequestParameterInType` enum alongside QUERY, PATH, and HEADER
- Cookie parameters in OpenAPI 3.x specs (`in: cookie`) are now recognized by the breaking change detection engine
- No new rule code was needed: existing rules R004-R008 and R017 (parameter deleted, required/optional change, type change, constraint changes) now automatically cover cookie parameters because they operate on the `RequestParameterInType` abstraction

## What changed

- `RequestParameterInType.java` - added `COOKIE("cookie")` enum constant
- `RequestParameterInTypeTest.java` - unit tests for all four enum values including the new COOKIE case
- `CookieParameterDeletedIntTest.java` - integration test verifying cookie parameter deletion is detected as breaking
- `swaggers/v3/request/cookieparameterdeleted/` - test fixtures (petstore.yaml with cookie param, petstore_v2.yaml with it removed)

Closes #204