### PR TITLE
feat(E2): add JUnit XML output format

### DIFF
--- a/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandlerTest.java
+++ b/swagger-brake-cli/src/test/java/com/docktape/swagger/brake/cli/options/handler/OutputFormatsHandlerTest.java
@@ -109,4 +109,14 @@ class OutputFormatsHandlerTest {
         // then
         assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.MARKDOWN));
     }
+
+    @Test
+    void testHandleShouldSetFormatToJunitWhenPropertyValueIsJunit() {
+        // given
+        Options options = new Options();
+        // when
+        underTest.handle("junit", options);
+        // then
+        assertThat(options.getOutputFormats()).isEqualTo(of(OutputFormat.JUNIT));
+    }
 }

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/report/JUnitReporter.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/report/JUnitReporter.java
@@ -1,0 +1,66 @@
+package com.docktape.swagger.brake.report;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import com.docktape.swagger.brake.core.ApiInfo;
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.report.file.DirectoryCreator;
+import com.docktape.swagger.brake.report.file.FileWriter;
+import com.docktape.swagger.brake.runner.OutputFormat;
+import java.util.Collection;
+import org.springframework.stereotype.Component;
+
+@Component
+class JUnitReporter extends AbstractFileReporter implements CheckableReporter {
+    private static final String DEFAULT_FILENAME = "swagger-brake-junit.xml";
+    private static final String VERSIONED_FILENAME_TEMPLATE = "swagger-brake-%s-junit.xml";
+
+    public JUnitReporter(FileWriter fileWriter, DirectoryCreator directoryCreator) {
+        super(fileWriter, directoryCreator);
+    }
+
+    @Override
+    protected String getFilename(ApiInfo apiInfo) {
+        if (apiInfo != null && isNotBlank(apiInfo.getVersion())) {
+            return VERSIONED_FILENAME_TEMPLATE.formatted(apiInfo.getVersion());
+        }
+        return DEFAULT_FILENAME;
+    }
+
+    @Override
+    protected String toFileContent(Collection<BreakingChange> breakingChanges, Collection<BreakingChange> ignoredBreakingChanges, ApiInfo apiInfo) {
+        int total = breakingChanges.size();
+        int failures = total;
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<testsuites name=\"swagger-brake\">\n");
+        sb.append("    <testsuite name=\"BreakingChanges\" tests=\"").append(total).append("\" failures=\"").append(failures).append("\">\n");
+        for (BreakingChange bc : breakingChanges) {
+            String name = escapeXml(bc.getRuleCode() + ": " + bc.getMessage());
+            String message = escapeXml(bc.getMessage());
+            sb.append("        <testcase name=\"").append(name).append("\" classname=\"swagger-brake\">\n");
+            sb.append("            <failure message=\"").append(message).append("\" type=\"BreakingChange\"/>\n");
+            sb.append("        </testcase>\n");
+        }
+        sb.append("    </testsuite>\n");
+        sb.append("</testsuites>\n");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean canReport(OutputFormat format) {
+        return OutputFormat.JUNIT.equals(format);
+    }
+
+    private String escapeXml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;");
+    }
+}

--- a/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/OutputFormat.java
+++ b/swagger-brake/src/main/java/com/docktape/swagger/brake/runner/OutputFormat.java
@@ -5,5 +5,6 @@ public enum OutputFormat {
     JSON,
     HTML,
     GITHUB_ACTIONS,
-    MARKDOWN
+    MARKDOWN,
+    JUNIT
 }

--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/report/JUnitReporterTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/report/JUnitReporterTest.java
@@ -1,0 +1,187 @@
+package com.docktape.swagger.brake.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import com.docktape.swagger.brake.core.ApiInfo;
+import com.docktape.swagger.brake.core.BreakingChange;
+import com.docktape.swagger.brake.report.file.DirectoryCreator;
+import com.docktape.swagger.brake.report.file.FileWriter;
+import com.docktape.swagger.brake.runner.Options;
+import com.docktape.swagger.brake.runner.OutputFormat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JUnitReporterTest {
+
+    @Mock
+    private FileWriter fileWriter;
+
+    @Mock
+    private DirectoryCreator directoryCreator;
+
+    @InjectMocks
+    private JUnitReporter underTest;
+
+    @Test
+    void testReportShouldWriteXmlFileWithFailureForEachBreakingChange() throws IOException {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        when(bc.getRuleCode()).thenReturn("R001");
+        when(bc.getMessage()).thenReturn("Path deleted: /api/v1/users");
+
+        Collection<BreakingChange> breakingChanges = Collections.singletonList(bc);
+
+        String outputFilePath = "outputFilePath";
+        Options options = new Options();
+        options.setOutputFilePath(outputFilePath);
+
+        // when
+        underTest.report(breakingChanges, options);
+
+        // then
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        then(directoryCreator).should().create(outputFilePath);
+        then(fileWriter).should().write(
+            org.mockito.ArgumentMatchers.eq(outputFilePath + File.separator + "swagger-brake-junit.xml"),
+            contentCaptor.capture()
+        );
+
+        String xml = contentCaptor.getValue();
+        assertThat(xml).contains("<testsuites name=\"swagger-brake\">");
+        assertThat(xml).contains("<testsuite name=\"BreakingChanges\" tests=\"1\" failures=\"1\">");
+        assertThat(xml).contains("<testcase name=\"R001: Path deleted: /api/v1/users\" classname=\"swagger-brake\">");
+        assertThat(xml).contains("<failure message=\"Path deleted: /api/v1/users\" type=\"BreakingChange\"/>");
+    }
+
+    @Test
+    void testReportShouldWriteXmlFileWithVersionedFilenameWhenApiInfoHasVersion() throws IOException {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        when(bc.getRuleCode()).thenReturn("R002");
+        when(bc.getMessage()).thenReturn("Some breaking change");
+
+        ApiInfo apiInfo = new ApiInfo();
+        apiInfo.setVersion("1.2.3");
+
+        Options options = new Options();
+        options.setOutputFilePath("out");
+
+        // when
+        underTest.report(Collections.singletonList(bc), Collections.emptyList(), options, apiInfo);
+
+        // then
+        then(fileWriter).should().write(
+            org.mockito.ArgumentMatchers.eq("out" + File.separator + "swagger-brake-1.2.3-junit.xml"),
+            org.mockito.ArgumentMatchers.anyString()
+        );
+    }
+
+    @Test
+    void testReportShouldProduceEmptyTestsuiteWhenNoBreakingChanges() throws IOException {
+        // given
+        Options options = new Options();
+        options.setOutputFilePath("out");
+
+        // when
+        underTest.report(Collections.emptyList(), options);
+
+        // then
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        then(fileWriter).should().write(org.mockito.ArgumentMatchers.anyString(), contentCaptor.capture());
+
+        String xml = contentCaptor.getValue();
+        assertThat(xml).contains("<testsuite name=\"BreakingChanges\" tests=\"0\" failures=\"0\">");
+        assertThat(xml).doesNotContain("<testcase");
+    }
+
+    @Test
+    void testReportShouldEscapeXmlSpecialCharactersInMessages() throws IOException {
+        // given
+        BreakingChange bc = mock(BreakingChange.class);
+        when(bc.getRuleCode()).thenReturn("R003");
+        when(bc.getMessage()).thenReturn("Field <name> changed to \"value\" & more");
+
+        Options options = new Options();
+        options.setOutputFilePath("out");
+
+        // when
+        underTest.report(Collections.singletonList(bc), options);
+
+        // then
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        then(fileWriter).should().write(org.mockito.ArgumentMatchers.anyString(), contentCaptor.capture());
+
+        String xml = contentCaptor.getValue();
+        assertThat(xml).contains("&lt;name&gt;");
+        assertThat(xml).contains("&quot;value&quot;");
+        assertThat(xml).contains("&amp; more");
+    }
+
+    @Test
+    void testReportShouldWriteMultipleTestcasesForMultipleBreakingChanges() throws IOException {
+        // given
+        BreakingChange bc1 = mock(BreakingChange.class);
+        when(bc1.getRuleCode()).thenReturn("R001");
+        when(bc1.getMessage()).thenReturn("First breaking change");
+
+        BreakingChange bc2 = mock(BreakingChange.class);
+        when(bc2.getRuleCode()).thenReturn("R002");
+        when(bc2.getMessage()).thenReturn("Second breaking change");
+
+        Options options = new Options();
+        options.setOutputFilePath("out");
+
+        // when
+        underTest.report(List.of(bc1, bc2), options);
+
+        // then
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        then(fileWriter).should().write(org.mockito.ArgumentMatchers.anyString(), contentCaptor.capture());
+
+        String xml = contentCaptor.getValue();
+        assertThat(xml).contains("<testsuite name=\"BreakingChanges\" tests=\"2\" failures=\"2\">");
+        assertThat(xml).contains("R001: First breaking change");
+        assertThat(xml).contains("R002: Second breaking change");
+    }
+
+    @Test
+    void testCanReportShouldReturnTrueIfOutputFormatIsJunit() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.JUNIT);
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseIfOutputFormatIsHtml() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.HTML);
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCanReportShouldReturnFalseIfOutputFormatIsJson() {
+        // given
+        // when
+        boolean result = underTest.canReport(OutputFormat.JSON);
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `JUNIT` to the `OutputFormat` enum alongside existing `STDOUT`, `JSON`, and `HTML` values
- Implements `JUnitReporter` that generates JUnit XML output compatible with GitLab MR widgets and Jenkins CI
- Extends `OutputFormatsHandlerTest` with a test case verifying the `"junit"` string maps to `OutputFormat.JUNIT`

Closes #229

## Output format example

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="swagger-brake">
    <testsuite name="BreakingChanges" tests="2" failures="2">
        <testcase name="R001: Path deleted: /api/v1/users" classname="swagger-brake">
            <failure message="Path deleted: /api/v1/users" type="BreakingChange"/>
        </testcase>
        <testcase name="R002: Response type changed for GET /api/v1/orders" classname="swagger-brake">
            <failure message="Response type changed for GET /api/v1/orders" type="BreakingChange"/>
        </testcase>
    </testsuite>
</testsuites>
```

## Usage

```
swagger-brake --output-formats=junit --output-path=target/reports ...
```

This produces `swagger-brake-junit.xml` (or `swagger-brake-{version}-junit.xml` when API version info is present) in the output directory. The file is ready to be consumed by GitLab's test reports or Jenkins' JUnit plugin.

## How it works

`JUnitReporter` extends `AbstractFileReporter` and is registered as a `@Component`. Spring auto-collects it into `ReporterFactory` alongside the existing reporters - no manual registration required.