### PR TITLE
docs: document new rules, constraints, output formats, and severity model

### DIFF
--- a/src-docs/src/changelog/README.md
+++ b/src-docs/src/changelog/README.md
@@ -15,6 +15,26 @@ The new `--strict-validation` option provides flexibility when customer specs ar
   * Union type detection with warnings for multiple non-null types
   * Full backward compatibility with Swagger 2.0 and OpenAPI 3.0.x specifications
 * Added `--max-log-serialization-depth` CLI option (and `maxLogSerializationDepth` configuration) to control depth of object serialization in logs (1-20 range, default: 3). See [Configuration documentation](../configuration/README.md#configuring-log-serialization-depth) for details.
+* Added a batch of new breaking change rules (see [Rules](../rules/README.md)):
+  * R021 - a request field or parameter gaining an `enum` constraint
+  * R022 - a required response property becoming optional
+  * R023 - an optional request body becoming required
+  * R024 - removal of a value from an `x-extensible-enum` request property
+  * R025 - loosening of a response-side constraint (e.g. larger `maxLength`, smaller `minItems`)
+  * R026 - a request parameter `default` value being added, changed, or removed
+  * R027 - a request property becoming non-nullable
+  * R028 - a response property becoming nullable
+  * R029 - tightening `additionalProperties` on a request schema (e.g. `true` to `false`)
+  * R030 / R031 - changes to a `const` value on a request / response property (OpenAPI 3.1)
+  * R032 - removal of a response header
+  * R033 - a required response header becoming optional
+  * R034 - generalization of a response media type (e.g. `application/vnd.api+json` to `application/json`)
+  * R035 - server URL changes (opt-in, off by default; enable with `--server-url-change-enabled=true`)
+* Extended the R017 constraint rule with `multipleOf` (number) and `pattern` (string) constraint detection. See [Constraints](../constraints/README.md).
+* Cookie parameters are now included in the existing request parameter rules (R004-R008, R017).
+* OpenAPI 3.1 webhook operations are now traversed by the breaking change rules.
+* Introduced an `ERROR`/`WARNING`/`INFO` severity model. All built-in rules report `ERROR`; the `--fail-on-severity` CLI option controls which severity (and above) fails the check. See [Severity model](../configuration/README.md#severity-model).
+* Added `MARKDOWN`, `GITHUB_ACTIONS` and `JUNIT` output formats. See [Customizing reporting](../configuration/README.md#customizing-reporting).
 
 ### Bug Fixes
 * Fixed StackOverflowError when processing OpenAPI 3.1.x schemas with circular references (e.g., Business → AuctionNumber → Business)

--- a/src-docs/src/cli/README.md
+++ b/src-docs/src/cli/README.md
@@ -34,9 +34,12 @@ reporting will always be enabled.
 
 To configure a custom reporting, the CLI accepts the `--output-formats` argument. The parameter
 accepts a comma separated list of reporting formats, in case you want to use multiple reporters.
+The supported values are `STDOUT`, `JSON`, `HTML`, `MARKDOWN`, `GITHUB_ACTIONS` and `JUNIT`.
 
-For file typed reporters like JSON or HTML, you must also pass the `--output-path` argument 
-denoting the location where the reports should be saved.
+For file typed reporters like JSON, HTML, MARKDOWN or JUNIT, you must also pass the `--output-path`
+argument denoting the location where the reports should be saved. The `GITHUB_ACTIONS` reporter
+writes `::error::` workflow commands to the console so the breaking changes show up as annotations
+on the GitHub Actions PR Files Changed tab.
 
 An example configuration could look the following:
 ```bash
@@ -171,12 +174,39 @@ $ java -jar swagger-brake.jar --old-api=swagger.yaml --new-api=swagger2.yaml --m
 ```
 
 
+## Severity model
+For a description of the severity model, see the
+[Severity model](../configuration/README.md#severity-model) section.
+
+Every breaking change is reported at the `ERROR` severity by the built-in rules. The
+`--fail-on-severity` parameter controls the minimum severity (inclusive) that causes a non-zero exit
+code. It accepts `error` (default), `warning` or `info`.
+
+```bash
+# Only ERROR level breaking changes fail the build (default)
+$ java -jar swagger-brake.jar --old-api=swagger.yaml --new-api=swagger2.yaml --fail-on-severity=error
+
+# Any reported change - including WARNING and INFO - fails the build
+$ java -jar swagger-brake.jar --old-api=swagger.yaml --new-api=swagger2.yaml --fail-on-severity=info
+```
+
+## Server URL change detection
+For a description of this rule, see the
+[Server URL change detection](../configuration/README.md#server-url-change-detection) section.
+
+Server URL changes are not checked by default. Enable [R035](../rules/README.md#r035---serverurlchangedrule-opt-in)
+by passing `--server-url-change-enabled=true`.
+
+```bash
+$ java -jar swagger-brake.jar --old-api=swagger.yaml --new-api=swagger2.yaml --server-url-change-enabled=true
+```
+
 ## Full list of parameters
 | <div style="width:250px">Parameter</div>   | Description                                                                                                                                               |
 |:------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|
 | `--old-api`                                | Denotes the path of the baseline API. Can be a relative path and an absolute one.                                                                         |
 | `--new-api`                                | Denotes the path of the new, changed API. Can be a relative path and an absolute one.                                                                     |
-| `--output-formats`                         | Specifies which reports shall be generated. Possible values: `STDOUT`, `JSON`, `HTML`                                                                     |
+| `--output-formats`                         | Specifies which reports shall be generated. Possible values: `STDOUT`, `JSON`, `HTML`, `MARKDOWN`, `GITHUB_ACTIONS`, `JUNIT`                               |
 | `--output-path`                            | Denotes the folder where the file reports shall be saved. Can be a relative path and an absolute one. In case the path doesn't exist, it will be created. |
 | `--maven-repo-url`                         | Specifies the release repository base URL. Might be optional in case `--maven-snapshot-repo-url` is provided.                                             |
 | `--maven-snapshot-repo-url`                | Specifies the snapshot repository base URL. Might be optional in case `--maven-repo-url` is provided.                                                     |
@@ -191,4 +221,6 @@ $ java -jar swagger-brake.jar --old-api=swagger.yaml --new-api=swagger2.yaml --m
 | `--excluded-paths`                         | A comma separated list of path prefixes that shall be excluded from the scan.                
 | `--ignored-breaking-change-rules`          | Specifies which breaking changes shall be ignored. Rules have to be provided (find them in the doc). Multiple values can be provided by using comma. Example: R001,R002 |
 | `--strict-validation`                      | Controls validation behavior for schemas with missing type fields. Default is `true` (strict mode). Set to `false` for lenient mode with specs missing type fields. |
-| `--max-log-serialization-depth`            | Controls the maximum depth of object serialization in logs (1-20). Default is 3. Prevents StackOverflowError with circular references.                    |                
+| `--max-log-serialization-depth`            | Controls the maximum depth of object serialization in logs (1-20). Default is 3. Prevents StackOverflowError with circular references.                    |
+| `--server-url-change-enabled`              | Enables detection of server URL changes (rule R035). Defaults to `false` since URL migrations are often intentional.                                       |
+| `--fail-on-severity`                       | The minimum severity at which a breaking change fails the check. Accepted values: `error` (default), `warning`, `info`.                                    |

--- a/src-docs/src/configuration/README.md
+++ b/src-docs/src/configuration/README.md
@@ -10,6 +10,15 @@ passed):
 * `STDOUT` (default)
 * `JSON`
 * `HTML`
+* `MARKDOWN`
+* `GITHUB_ACTIONS`
+* `JUNIT`
+
+**MARKDOWN**: Generates a Markdown report file suitable for wikis, GitHub pull request comments, and other Markdown-aware systems.
+
+**GITHUB_ACTIONS**: Writes `::error::` workflow commands to stdout so that breaking changes are annotated on the PR Files Changed tab in GitHub Actions.
+
+**JUNIT**: Generates a JUnit XML report that can be picked up by CI systems (Jenkins, GitHub Actions, etc.) as a test result.
 
 CLI configuration [here](../cli/README.md#customizing-reporting).
 
@@ -29,7 +38,8 @@ An example JSON report looks the following:
     "pathDeletedBreakingChange" : [ {
       "path" : "/pet",
       "method" : "POST",
-      "message" : "Path /pet POST has been deleted"
+      "message" : "Path /pet POST has been deleted",
+      "severity" : "ERROR"
     } ]  
   }
 }
@@ -38,6 +48,37 @@ In case of no breaking changes, the JSON report will be an empty JSON.
 ```json
 { }
 ```
+
+## Severity model
+Every detected breaking change carries a severity. swagger-brake defines three levels:
+
+* `ERROR`
+* `WARNING`
+* `INFO`
+
+Currently all built-in rules report their breaking changes as `ERROR`, so by default any breaking
+change fails the check. The `WARNING` and `INFO` levels exist in the model so that the failure
+threshold can be tuned and so that future or custom rules can report at a lower severity.
+
+The severity is surfaced in the output:
+* the `STDOUT` reporter prefixes every line with the severity, e.g. `[ERROR] R002 Path /pet POST has been deleted`
+* the `JSON` reporter adds a `severity` field to each breaking change (see the example above)
+
+You can control which severity (and above) causes a non-zero exit code with the `fail-on-severity`
+setting. It accepts `error` (default), `warning`, or `info`. For example setting it to `info` makes
+every reported change - regardless of severity - fail the check, while `error` only fails on `ERROR`
+level changes.
+
+This is currently configurable through the CLI only - see the
+[CLI severity model](../cli/README.md#severity-model) section. The Maven and Gradle plugins always
+fail on any breaking change.
+
+## Server URL change detection
+By default, server URL changes are not reported as breaking changes because URL migrations are often intentional. To opt in:
+
+CLI: pass `--server-url-change-enabled=true`
+
+This enables [R035](../rules/README.md#r035---serverurlchangedrule-opt-in) which flags when a server URL is removed or modified between versions. This option is currently available through the CLI only.
 
 ## Deprecating APIs
 As an API evolves and time passes, some APIs might simply become unused and old.

--- a/src-docs/src/constraints/README.md
+++ b/src-docs/src/constraints/README.md
@@ -17,6 +17,13 @@ has the following definition with `maxLength`:
 Did not find the constraint you're looking for? It might not be implemented, feel free to file a ticket on 
 [GitHub](https://github.com/docktape/swagger-brake/issues).
 
+::: tip Response-side constraint checking
+As of R025 (`ResponseConstraintChangedRule`), all constraint checkers documented here also apply to
+**response schemas** with inverted logic: loosening a constraint on a response property is a breaking
+change. For example, raising a `maxLength` or increasing a `maximum` on a response field can break
+clients that sized buffers or validated values against the original bound.
+:::
+
 ## Array constraints
 ### maxItems constraint
 This constraint checks whether the `maxItems` constraint on an array typed attribute has been changed in a backward-incomptabile
@@ -185,6 +192,37 @@ swagger2.json
 }]
 ```
 
+### multipleOf constraint
+This constraint checks whether the `multipleOf` constraint on a number typed attribute has been changed in a backward-incompatible
+way:
+* if the old API did not have a `multipleOf` constraint at all but the new API has it
+* if the old API did have a `multipleOf` constraint and the new API has it too but it's a different value
+
+Removing `multipleOf` is not reported as a breaking change since it loosens the constraint.
+
+swagger.json
+```json
+"parameters": [{
+    "name": "quantity",
+    "in": "query",
+    "description": "Number of items",
+    "required": true,
+    "type": "integer"
+}]
+```
+
+swagger2.json
+```json
+"parameters": [{
+    "name": "quantity",
+    "in": "query",
+    "description": "Number of items",
+    "required": true,
+    "type": "integer",
+    "multipleOf": 5
+}]
+```
+
 ## String constraints
 ### maxLength constraint
 This constraint checks whether the `maxLength` constraint on a number typed attribute has been changed in a backward-incomptabile
@@ -243,5 +281,34 @@ swagger2.json
     "required": true,
     "type": "string",
     "minLength": 8
+}]
+```
+
+### pattern constraint
+This constraint checks whether a `pattern` (regex) constraint on a string typed attribute has been changed in a backward-incompatible
+way:
+* if the old API did not have a `pattern` constraint at all but the new API has it
+* if the old API did have a `pattern` constraint and the new API has it too but it's a different regex
+
+swagger.json
+```json
+"parameters": [{
+    "name": "code",
+    "in": "query",
+    "description": "Three-letter country code",
+    "required": true,
+    "type": "string"
+}]
+```
+
+swagger2.json
+```json
+"parameters": [{
+    "name": "code",
+    "in": "query",
+    "description": "Three-letter country code",
+    "required": true,
+    "type": "string",
+    "pattern": "^[A-Z]{3}$"
 }]
 ```

--- a/src-docs/src/gradle/README.md
+++ b/src-docs/src/gradle/README.md
@@ -66,7 +66,7 @@ see the HTML report generated under the `build/swagger-brake` folder. For reconf
 `outputFilePath` parameter.
 
 Overriding the reporting configuration is simple. In the plugin configuration, just set the `outputFormats` attribute with
-an array of values.
+an array of values. The supported values are `STDOUT`, `JSON`, `HTML`, `MARKDOWN`, `GITHUB_ACTIONS` and `JUNIT`.
 
 Example:
 ```groovy
@@ -199,7 +199,7 @@ swaggerBrake {
 |:--------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|
 | `oldApi`                   | Denotes the path of the baseline API. Can be a relative path and an absolute one.                                                                         |
 | `newApi`                   | Denotes the path of the new, changed API. Can be a relative path and an absolute one.                                                                     |
-| `outputFormats`            | Specifies which reports shall be generated. Possible values: `STDOUT`, `JSON`, `HTML`                                                                     |
+| `outputFormats`            | Specifies which reports shall be generated. Possible values: `STDOUT`, `JSON`, `HTML`, `MARKDOWN`, `GITHUB_ACTIONS`, `JUNIT`                              |
 | `outputFilePath`           | Denotes the folder where the file reports shall be saved. Can be a relative path and an absolute one. In case the path doesn't exist, it will be created. |
 | `mavenRepoUrl`             | Specifies the release repository base URL. Might be optional in case `mavenSnapshotRepoUrl` is provided.                                                  |
 | `mavenSnapshotRepoUrl`     | Specifies the snapshot repository base URL. Might be optional in case `mavenRepoUrl` is provided.                                                         |

--- a/src-docs/src/maven/README.md
+++ b/src-docs/src/maven/README.md
@@ -68,7 +68,8 @@ see the HTML report generated under the `target/swagger-brake` folder. For recon
 `<outputFilePath>` parameter.
 
 Overriding the reporting configuration is simple. In the plugin configuration, just set the `<outputFormats>` tag with
-an array of `<outputFormat>` values.
+an array of `<outputFormat>` values. The supported values are `STDOUT`, `JSON`, `HTML`, `MARKDOWN`,
+`GITHUB_ACTIONS` and `JUNIT`.
 
 Example:
 ```xml
@@ -317,7 +318,7 @@ Example:
 |:------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|
 |           `<oldApi>`           |                                     Denotes the path of the baseline API. Can be a relative path and an absolute one.                                     |
 |           `<newApi>`           |                                   Denotes the path of the new, changed API. Can be a relative path and an absolute one.                                   |
-|       `<outputFormats>`        |                                   Specifies which reports shall be generated. Possible values: `STDOUT`, `JSON`, `HTML`                                   |
+|       `<outputFormats>`        |                     Specifies which reports shall be generated. Possible values: `STDOUT`, `JSON`, `HTML`, `MARKDOWN`, `GITHUB_ACTIONS`, `JUNIT`          |
 |       `<outputFilePath>`       | Denotes the folder where the file reports shall be saved. Can be a relative path and an absolute one. In case the path doesn't exist, it will be created. |
 |        `<mavenRepoUrl>`        |                        Specifies the release repository base URL. Might be optional in case `<mavenSnapshotRepoUrl>` is provided.                         |
 |    `<mavenSnapshotRepoUrl>`    |                            Specifies the snapshot repository base URL. Might be optional in case `<mavenRepoUrl>` is provided.                            |

--- a/src-docs/src/rules/README.md
+++ b/src-docs/src/rules/README.md
@@ -5,6 +5,12 @@ as a breaking change in an API.
 Did not find the rule you're looking for? It might not be implemented, feel free to file a ticket on 
 [GitHub](https://github.com/docktape/swagger-brake/issues).
 
+::: tip Cookie parameter support
+Cookie parameters (`in: cookie`) are now fully supported. All existing parameter rules
+(R004, R005, R006, R007, R008, R017) apply to cookie parameters in the same way they apply
+to query, header, and path parameters.
+:::
+
 ## R001 - StandardApiToBetaApiRule
 The rule addresses the case when a normal - non-beta API - is marked as beta in the new API, meaning that an exposed
 API has been switched into beta mode to introduce potential breaking changes.
@@ -766,3 +772,404 @@ definitions:
 ## R017 - RequestParameterConstraintChangeRule
 This is a wrapper rule that checks for any type of constraint violation. For specific constraints, check out the
 [Constraints](../constraints/README.md) section.
+
+## R021 - RequestBodyBecameEnumRule
+A request property or parameter that previously had no `enum` constraint gaining one is a breaking change.
+Clients that were sending values outside the newly introduced enum will now receive a rejection.
+
+swagger.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        status:
+          type: string
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+          - available
+          - pending
+          - sold
+```
+
+## R022 - ResponsePropertyBecameOptionalRule
+A response property changing from required to optional is a breaking change. Clients that depend on the
+property always being present in the response will break if the server stops including it.
+
+swagger.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+      required:
+        - id
+        - name
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+      required:
+        - id
+```
+
+## R023 - RequestBodyBecameRequiredRule
+An optional request body flipping to `required: true` is a breaking change for clients that currently omit
+the body when calling the endpoint.
+
+swagger.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+```
+
+## R024 - RequestTypeXExtensibleEnumValueDeletedRule
+Removal of a value from an `x-extensible-enum` vendor extension is treated the same as removing a regular
+enum value. Clients that send the removed value will receive a rejection from the server.
+
+swagger.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        status:
+          type: string
+          x-extensible-enum:
+          - available
+          - pending
+          - sold
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        status:
+          type: string
+          x-extensible-enum:
+          - available
+          - sold
+```
+
+## R025 - ResponseConstraintChangedRule
+Existing constraint checks (array bounds, number bounds, string length) now also apply to response schemas,
+with inverted direction: loosening a constraint on a response is a breaking change. For example, increasing
+`maxLength` or raising `maximum` on a response property can break clients that sized buffers to the old bound.
+
+See the [Constraints](../constraints/README.md) section for the full list of checked constraints.
+
+## R026 - RequestParameterDefaultChangedRule
+Adding, changing, or removing a `default` value on a request parameter is a breaking change. The default
+determines the effective value used when the parameter is omitted, so any change alters observable server
+behavior for clients that rely on parameter omission.
+
+swagger.yaml
+```yaml
+parameters:
+  - name: limit
+    in: query
+    type: integer
+    default: 20
+```
+
+swagger2.yaml
+```yaml
+parameters:
+  - name: limit
+    in: query
+    type: integer
+    default: 50
+```
+
+## R027 - RequestPropertyBecameNonNullableRule
+A request property that was nullable (OpenAPI 3.0 `nullable: true`, or OpenAPI 3.1 `type: ["T", "null"]`)
+becoming non-nullable is a breaking change. Clients that were sending `null` for that property will now
+receive a rejection.
+
+swagger.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+```
+
+## R028 - ResponsePropertyBecameNullableRule
+A response property that was not nullable becoming nullable is a breaking change for clients that do not
+expect `null` values. Typed clients may throw a NullPointerException or similar error when deserializing
+a `null` into a non-nullable field.
+
+swagger.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+```
+
+## R029 - RequestAdditionalPropertiesTightenedRule
+Setting `additionalProperties: false` on a request schema that previously had `additionalProperties: true`
+or no restriction rejects payloads with extra properties that were previously accepted.
+
+swagger.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties: false
+```
+
+## R030 - RequestPropertyConstChangedRule *(OpenAPI 3.1)*
+Adding or changing a `const` value on a request property narrows the set of accepted values to only the
+exact const value. This is a breaking change for clients that were sending other values.
+
+swagger.yaml (OpenAPI 3.1)
+```yaml
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        version:
+          type: string
+```
+
+swagger2.yaml (OpenAPI 3.1)
+```yaml
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        version:
+          type: string
+          const: "2.0"
+```
+
+## R031 - ResponsePropertyConstChangedRule *(OpenAPI 3.1)*
+Changing or removing a `const` value on a response property is a breaking change for clients that validate
+or pattern-match against the specific const value in the response.
+
+swagger.yaml (OpenAPI 3.1)
+```yaml
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        version:
+          type: string
+          const: "1.0"
+```
+
+swagger2.yaml (OpenAPI 3.1)
+```yaml
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        version:
+          type: string
+          const: "2.0"
+```
+
+## R032 - ResponseHeaderDeletedRule
+Removing a documented response header that was previously required breaks clients that depend on its
+presence. Clients reading the header will receive an absent value where they expected one.
+
+swagger.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    post:
+      responses:
+        200:
+          headers:
+            X-Rate-Limit:
+              schema:
+                type: integer
+              required: true
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    post:
+      responses:
+        200:
+          headers: {}
+```
+
+## R033 - ResponseHeaderBecameOptionalRule
+A required response header becoming optional is a breaking change for clients that rely on the header
+always being present in the response.
+
+swagger.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    post:
+      responses:
+        200:
+          headers:
+            X-Rate-Limit:
+              schema:
+                type: integer
+              required: true
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    post:
+      responses:
+        200:
+          headers:
+            X-Rate-Limit:
+              schema:
+                type: integer
+              required: false
+```
+
+## R034 - ResponseMediaTypeGeneralizedRule
+Generalizing a response media type (for example from `application/vnd.foo+json` to `application/json`)
+can break content negotiation for clients that relied on the specific vendor media type.
+
+swagger.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    get:
+      responses:
+        200:
+          content:
+            application/vnd.petstore.v1+json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+```
+
+swagger2.yaml (OpenAPI3)
+```yaml
+paths:
+  /pet:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+```
+
+## R035 - ServerUrlChangedRule *(opt-in)*
+A server URL being removed or changed breaks clients that have the URL hardcoded. Because server URL changes
+are often intentional (for example, promoting from staging to production), this rule is **disabled by default**.
+
+See the [Server URL change detection](../configuration/README.md#server-url-change-detection) section for how
+to enable it.
+
+---
+
+## Webhooks (OpenAPI 3.1)
+
+OpenAPI 3.1 introduced first-class support for `webhooks` alongside `paths`. swagger-brake applies all
+existing operation-level rules to webhook operations as well. This means path deletion, request body
+changes, response changes, and all parameter rules also trigger breaking change reports when the change
+occurs in a webhook definition.


### PR DESCRIPTION
## Summary

Comprehensive documentation update for everything merged since R017. Originally this PR only touched 3 files; it now covers all 7 affected docs pages and fixes several accuracy issues.

### rules/README.md
- R021-R035 documented with descriptions and examples
- **Corrected 5 rule class names** to match the real implementations (e.g. `ResponseHeaderRemovedRule` -> `ResponseHeaderDeletedRule`, `RequestPropertyBecameNotNullableRule` -> `RequestPropertyBecameNonNullableRule`)
- Cookie parameter coverage note (R004-R008, R017)
- OpenAPI 3.1 webhook coverage note

### constraints/README.md
- `multipleOf` (number) and `pattern` (string) constraints
- Response-side constraint loosening note (R025)

### configuration/README.md
- New `MARKDOWN`, `GITHUB_ACTIONS`, `JUNIT` output formats
- **Severity model rewritten to match the implementation**: all built-in rules report `ERROR`; `WARNING`/`INFO` exist as a `fail-on-severity` threshold, not as per-rule classifications (the previous draft invented meanings for them)
- Added the new `severity` field to the JSON report example
- **Removed dangling `#severity-model` links** to the Maven/Gradle pages (those plugins do not support the option yet)
- Server URL change detection (R035) opt-in

### cli/README.md
- `--output-formats` value list updated
- New `--server-url-change-enabled` and `--fail-on-severity` parameters
- New **Severity model** and **Server URL change detection** sections so the configuration cross-links resolve

### maven/README.md, gradle/README.md
- Output format value lists updated (these plugins pick up the new formats automatically via `OutputFormat.valueOf()`; `fail-on-severity` / `server-url-change` remain CLI-only for now)

### changelog/README.md
- Entry summarizing the new rules, constraints, output formats, and severity model

## Verification
All 15 documented rule class names cross-checked against the actual source classes. All internal cross-document anchor links resolve.