### PR TITLE
fix: update ResponseMediaTypeGeneralizedRuleTest to use 3-arg Response constructor

### DIFF
--- a/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
+++ b/swagger-brake/src/test/java/com/docktape/swagger/brake/core/rule/response/ResponseMediaTypeGeneralizedRuleTest.java
@@ -41,11 +41,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -72,7 +72,7 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> mediaTypes = new HashMap<>();
         mediaTypes.put(mediaType, schema);
-        Response response = new Response("200", mediaTypes);
+        Response response = new Response("200", mediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(response), false, false);
@@ -96,12 +96,12 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(oldMediaType, schema);
         newMediaTypes.put(newGeneralMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);
@@ -125,11 +125,11 @@ class ResponseMediaTypeGeneralizedRuleTest {
 
         Map<MediaType, Schema> oldMediaTypes = new HashMap<>();
         oldMediaTypes.put(oldMediaType, schema);
-        Response oldResponse = new Response("200", oldMediaTypes);
+        Response oldResponse = new Response("200", oldMediaTypes, Collections.emptyMap());
 
         Map<MediaType, Schema> newMediaTypes = new HashMap<>();
         newMediaTypes.put(newMediaType, schema);
-        Response newResponse = new Response("200", newMediaTypes);
+        Response newResponse = new Response("200", newMediaTypes, Collections.emptyMap());
 
         Path oldPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(oldResponse), false, false);
         Path newPath = new Path("/pets", HttpMethod.GET, null, Collections.emptyList(), List.of(newResponse), false, false);


### PR DESCRIPTION
## Summary

- R032 (`feat(R032)`) added a `headers` field to the `Response` model, changing its Lombok-generated constructor from 2-arg to 3-arg (code, mediaTypes, headers).
- `ResponseMediaTypeGeneralizedRuleTest.java` was not updated in that PR, leaving 7 calls to the old 2-arg constructor.
- This caused a compile failure on master, breaking CI for all subsequent commits.

## Fix

Updated all 7 `new Response("200", ...)` calls in the test to `new Response("200", ..., Collections.emptyMap())`.